### PR TITLE
Add notice to source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Generating OpenQASM 3 + OpenPulse in Python"
 authors = ["OQpy Contributors <oqpy-contributors@amazon.com>"]
 license = "Apache-2.0"
+include = ["NOTICE"]
 readme = "README.md"
 repository = "https://github.com/openqasm/oqpy"
 keywords = ["openqasm", "quantum"]


### PR DESCRIPTION
Currently, the notice is not distributed with the source distribution. As it is part of the copyright, it should. This PR should include that.