### PR TITLE
Add support for arguments & return types to defcals

### DIFF
--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -65,6 +65,12 @@ class OQPyExpression:
         """Helper method to produce a binary expression."""
         return OQPyUnaryExpression(ast.UnaryOperator[op_name], exp)
 
+    def __pos__(self) -> OQPyExpression:
+        return self
+
+    def __neg__(self) -> OQPyUnaryExpression:
+        return self._to_unary("-", self)
+
     def __add__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("+", self, other)
 
@@ -76,9 +82,6 @@ class OQPyExpression:
 
     def __rsub__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("-", other, self)
-
-    def __neg__(self) -> OQPyUnaryExpression:
-        return self._to_unary("-", self)
 
     def __mod__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("%", self, other)
@@ -97,6 +100,12 @@ class OQPyExpression:
 
     def __rtruediv__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("/", other, self)
+
+    def __pow__(self, other: AstConvertible) -> OQPyBinaryExpression:
+        return self._to_binary("**", self, other)
+
+    def __pow__(self, other: AstConvertible) -> OQPyBinaryExpression:
+        return self._to_binary("**", other, self)
 
     def __eq__(self, other: AstConvertible) -> OQPyBinaryExpression:  # type: ignore[override]
         return self._to_binary("==", self, other)
@@ -153,7 +162,7 @@ class ExpressionConvertible(Protocol):
 
 
 class OQPyUnaryExpression(OQPyExpression):
-    """An expression consisting of one expressions preceded by an operator."""
+    """An expression consisting of one expression preceded by an operator."""
 
     def __init__(self, op: ast.UnaryOperator, exp: AstConvertible):
         super().__init__()

--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -104,7 +104,7 @@ class OQPyExpression:
     def __pow__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("**", self, other)
 
-    def __pow__(self, other: AstConvertible) -> OQPyBinaryExpression:
+    def __rpow__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("**", other, self)
 
     def __eq__(self, other: AstConvertible) -> OQPyBinaryExpression:  # type: ignore[override]

--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -60,11 +60,25 @@ class OQPyExpression:
         """Helper method to produce a binary expression."""
         return OQPyBinaryExpression(ast.BinaryOperator[op_name], first, second)
 
+    @staticmethod
+    def _to_unary(op_name: str, exp: AstConvertible) -> OQPyUnaryExpression:
+        """Helper method to produce a binary expression."""
+        return OQPyUnaryExpression(ast.UnaryOperator[op_name], exp)
+
     def __add__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("+", self, other)
 
     def __radd__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("+", other, self)
+
+    def __sub__(self, other: AstConvertible) -> OQPyBinaryExpression:
+        return self._to_binary("-", self, other)
+
+    def __rsub__(self, other: AstConvertible) -> OQPyBinaryExpression:
+        return self._to_binary("-", other, self)
+
+    def __neg__(self) -> OQPyUnaryExpression:
+        return self._to_unary("-", self)
 
     def __mod__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("%", self, other)
@@ -77,6 +91,12 @@ class OQPyExpression:
 
     def __rmul__(self, other: AstConvertible) -> OQPyBinaryExpression:
         return self._to_binary("*", other, self)
+
+    def __truediv__(self, other: AstConvertible) -> OQPyBinaryExpression:
+        return self._to_binary("/", self, other)
+
+    def __rtruediv__(self, other: AstConvertible) -> OQPyBinaryExpression:
+        return self._to_binary("/", other, self)
 
     def __eq__(self, other: AstConvertible) -> OQPyBinaryExpression:  # type: ignore[override]
         return self._to_binary("==", self, other)
@@ -130,6 +150,23 @@ class ExpressionConvertible(Protocol):
 
     def _to_oqpy_expression(self) -> HasToAst:
         ...
+
+
+class OQPyUnaryExpression(OQPyExpression):
+    """An expression consisting of one expressions preceded by an operator."""
+
+    def __init__(self, op: ast.UnaryOperator, exp: AstConvertible):
+        super().__init__()
+        self.op = op
+        self.exp = exp
+        if isinstance(exp, OQPyExpression):
+            self.type = exp.type
+        else:
+            raise TypeError("exp is an expression")
+
+    def to_ast(self, program: Program) -> ast.UnaryExpression:
+        """Converts the OQpy expression into an ast node."""
+        return ast.UnaryExpression(self.op, to_ast(program, self.exp))
 
 
 class OQPyBinaryExpression(OQPyExpression):

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -140,6 +140,8 @@ def convert_range(program: Program, item: Union[slice, range]) -> ast.RangeDefin
 
 
 class Identifier(OQPyExpression):
+    """Base class to specify constant symbols."""
+
     name: str
 
     def __init__(self, name: str) -> None:

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -53,6 +53,7 @@ __all__ = [
     "stretch",
     "bool_",
     "bit_",
+    "bit",
     "bit8",
     "convert_range",
     "int_",
@@ -78,24 +79,24 @@ __all__ = [
 # subclasses of ``_ClassicalVar`` instead.
 
 
-def int_(size: int) -> ast.IntType:
+def int_(size: int | None = None) -> ast.IntType:
     """Create a sized signed integer type."""
-    return ast.IntType(ast.IntegerLiteral(size))
+    return ast.IntType(ast.IntegerLiteral(size) if size is not None else None)
 
 
-def uint_(size: int) -> ast.UintType:
+def uint_(size: int | None = None) -> ast.UintType:
     """Create a sized unsigned integer type."""
-    return ast.UintType(ast.IntegerLiteral(size))
+    return ast.UintType(ast.IntegerLiteral(size) if size is not None else None)
 
 
-def float_(size: int) -> ast.FloatType:
+def float_(size: int | None = None) -> ast.FloatType:
     """Create a sized floating-point type."""
-    return ast.FloatType(ast.IntegerLiteral(size))
+    return ast.FloatType(ast.IntegerLiteral(size) if size is not None else None)
 
 
-def angle_(size: int) -> ast.AngleType:
+def angle_(size: int | None = None) -> ast.AngleType:
     """Create a sized angle type."""
-    return ast.AngleType(ast.IntegerLiteral(size))
+    return ast.AngleType(ast.IntegerLiteral(size) if size is not None else None)
 
 
 def complex_(size: int) -> ast.ComplexType:
@@ -107,14 +108,15 @@ def complex_(size: int) -> ast.ComplexType:
     return ast.ComplexType(ast.FloatType(ast.IntegerLiteral(size // 2)))
 
 
-def bit_(size: int) -> ast.BitType:
+def bit_(size: int | None = None) -> ast.BitType:
     """Create a sized bit type."""
-    return ast.BitType(ast.IntegerLiteral(size))
+    return ast.BitType(ast.IntegerLiteral(size) if size is not None else None)
 
 
 duration = ast.DurationType()
 stretch = ast.StretchType()
 bool_ = ast.BoolType()
+bit = ast.BitType()
 bit8 = bit_(8)
 int32 = int_(32)
 int64 = int_(64)

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from oqpy.program import Program
 
 __all__ = [
+    "pi",
     "BoolVar",
     "IntVar",
     "UintVar",
@@ -136,6 +137,20 @@ def convert_range(program: Program, item: Union[slice, range]) -> ast.RangeDefin
         to_ast(program, item.stop - 1),
         to_ast(program, item.step) if item.step != 1 else None,
     )
+
+
+class Identifier(OQPyExpression):
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.type = None
+        self.name = name
+
+    def to_ast(self, program: Program) -> ast.Expression:
+        return ast.Identifier(name=self.name)
+
+
+pi = Identifier(name="pi")
 
 
 class _ClassicalVar(Var, OQPyExpression):

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -82,7 +82,9 @@ class Program:
 
     def __init__(self, version: Optional[str] = "3.0") -> None:
         self.stack: list[ProgramState] = [ProgramState()]
-        self.defcals: dict[tuple[tuple[str, ...], str], ast.CalibrationDefinition] = {}
+        self.defcals: dict[
+            tuple[tuple[str, ...], str, tuple[str, ...]], ast.CalibrationDefinition
+        ] = {}
         self.subroutines: dict[str, ast.SubroutineDefinition] = {}
         self.externs: dict[str, ast.ExternDeclaration] = {}
         self.declared_vars: dict[str, Var] = {}
@@ -196,13 +198,17 @@ class Program:
         self.subroutines[name] = stmt
 
     def _add_defcal(
-        self, qubit_names: list[str], name: str, stmt: ast.CalibrationDefinition
+        self,
+        qubit_names: list[str],
+        name: str,
+        arguments: list[str],
+        stmt: ast.CalibrationDefinition,
     ) -> None:
         """Register a defcal defined in this program.
 
         Defcals are added to the top of the program upon conversion to ast.
         """
-        self.defcals[(tuple(qubit_names), name)] = stmt
+        self.defcals[(tuple(qubit_names), name, tuple(arguments))] = stmt
 
     def _make_externs_statements(self, auto_encal: bool = False) -> list[ast.ExternDeclaration]:
         """Return a list of extern statements for inclusion at beginning of program.

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Iterator, Optional, Union
 from openpulse import ast
 from openpulse.printer import dumps
 
-from oqpy.base import Var
+from oqpy.base import AstConvertible, Var, to_ast
 from oqpy.classical_types import _ClassicalVar
 
 if TYPE_CHECKING:
@@ -70,14 +70,14 @@ def defcal(
     program: Program,
     qubits: Union[Qubit, list[Qubit]],
     name: str,
-    arguments: Optional[list[Union[_ClassicalVar, str]]] = None,
+    arguments: Optional[list[AstConvertible]] = None,
     return_type: Optional[ast.ClassicalType] = None,
 ) -> Union[Iterator[None], Iterator[list[_ClassicalVar]], Iterator[_ClassicalVar]]:
     """Context manager for creating a defcal.
 
     .. code-block:: python
 
-        with defcal(program, q1, "X", [AngleVar(name="theta"), "pi/2"], oqpy.bit) as theta:
+        with defcal(program, q1, "X", [AngleVar(name="theta"), oqpy.pi/2], oqpy.bit) as theta:
             program.play(frame, waveform)
     """
     if isinstance(qubits, Qubit):
@@ -94,10 +94,8 @@ def defcal(
                 )
                 arg._needs_declaration = False
                 variables.append(arg)
-            elif isinstance(arg, str):
-                arguments_ast.append(ast.Identifier(name=arg))
             else:
-                raise TypeError(f"{arg} should be of type oqpy._Classical or str")
+                arguments_ast.append(to_ast(program, arg))
 
     program._push()
     if len(variables) > 1:

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -528,10 +528,10 @@ def test_defcals():
         prog.increment(theta, 0.1)
         prog.play(q_frame, constant(1e-6, 0.1))
 
-    with defcal(prog, q2, "rx", ["pi/2"]):
+    with defcal(prog, q2, "rx", [pi/3]):
         prog.play(q_frame, constant(1e-6, 0.1))
 
-    with defcal(prog, [q1, q2], "xy", [AngleVar(name="theta"), "pi/2"]) as theta:
+    with defcal(prog, [q1, q2], "xy", [AngleVar(name="theta"), -pi/2]) as theta:
         prog.increment(theta, 0.1)
         prog.play(q_frame, constant(1e-6, 0.1))
 
@@ -568,10 +568,10 @@ def test_defcals():
             theta += 0.1;
             play(q_frame, constant(1000.0ns, 0.1));
         }
-        defcal rx(pi/2) $2 {
+        defcal rx(pi / 3) $2 {
             play(q_frame, constant(1000.0ns, 0.1));
         }
-        defcal xy(angle[32] theta, pi/2) $1, $2 {
+        defcal xy(angle[32] theta, -pi / 2) $1, $2 {
             theta += 0.1;
             play(q_frame, constant(1000.0ns, 0.1));
         }
@@ -602,18 +602,18 @@ def test_defcals():
     )
     expect_defcal_rx_pio2 = textwrap.dedent(
         """
-        defcal rx(pi/2) $2 {
+        defcal rx(pi / 3) $2 {
             play(q_frame, constant(1000.0ns, 0.1));
         }
         """
     ).strip()
     assert (
-        dumps(prog.defcals[(("$2",), "rx", ("pi/2",))], indent="    ").strip()
+        dumps(prog.defcals[(("$2",), "rx", ("pi / 3",))], indent="    ").strip()
         == expect_defcal_rx_pio2
     )
     expect_defcal_xy_theta_pio2 = textwrap.dedent(
         """
-        defcal xy(angle[32] theta, pi/2) $1, $2 {
+        defcal xy(angle[32] theta, -pi / 2) $1, $2 {
             theta += 0.1;
             play(q_frame, constant(1000.0ns, 0.1));
         }
@@ -621,7 +621,7 @@ def test_defcals():
     ).strip()
     assert (
         dumps(
-            prog.defcals[(("$1", "$2"), "xy", ("angle[32] theta", "pi/2"))], indent="    "
+            prog.defcals[(("$1", "$2"), "xy", ("angle[32] theta", "-pi / 2"))], indent="    "
         ).strip()
         == expect_defcal_xy_theta_pio2
     )

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -190,6 +190,9 @@ def test_binary_expressions():
     j = IntVar(2, "j")
     prog.set(i, 2 * (i + j))
     prog.set(j, 2 % (2 + i) % 2)
+    prog.set(j, oqpy.pi)
+    prog.set(j, oqpy.pi / 2)
+    prog.set(j, -oqpy.pi * oqpy.pi + i)
 
     expected = textwrap.dedent(
         """
@@ -198,6 +201,9 @@ def test_binary_expressions():
         int[32] j = 2;
         i = 2 * (i + j);
         j = 2 % (2 + i) % 2;
+        j = pi;
+        j = pi / 2;
+        j = -pi * pi + i;
         """
     ).strip()
 
@@ -528,14 +534,14 @@ def test_defcals():
         prog.increment(theta, 0.1)
         prog.play(q_frame, constant(1e-6, 0.1))
 
-    with defcal(prog, q2, "rx", [pi/3]):
+    with defcal(prog, q2, "rx", [pi / 3]):
         prog.play(q_frame, constant(1e-6, 0.1))
 
-    with defcal(prog, [q1, q2], "xy", [AngleVar(name="theta"), -pi/2]) as theta:
+    with defcal(prog, [q1, q2], "xy", [AngleVar(name="theta"), -pi / 2]) as theta:
         prog.increment(theta, 0.1)
         prog.play(q_frame, constant(1e-6, 0.1))
 
-    with defcal(prog, [q1, q2], "xy", [AngleVar(name="theta"), FloatVar(name="phi")]) as params:
+    with defcal(prog, [q1, q2], "xy", [AngleVar(name="theta"), FloatVar(name="phi"), 10]) as params:
         theta, phi = params
         prog.increment(theta, 0.1)
         prog.increment(phi, 0.2)
@@ -575,7 +581,7 @@ def test_defcals():
             theta += 0.1;
             play(q_frame, constant(1000.0ns, 0.1));
         }
-        defcal xy(angle[32] theta, float[64] phi) $1, $2 {
+        defcal xy(angle[32] theta, float[64] phi, 10) $1, $2 {
             theta += 0.1;
             phi += 0.2;
             play(q_frame, constant(1000.0ns, 0.1));
@@ -627,7 +633,7 @@ def test_defcals():
     )
     expect_defcal_xy_theta_phi = textwrap.dedent(
         """
-        defcal xy(angle[32] theta, float[64] phi) $1, $2 {
+        defcal xy(angle[32] theta, float[64] phi, 10) $1, $2 {
             theta += 0.1;
             phi += 0.2;
             play(q_frame, constant(1000.0ns, 0.1));
@@ -636,7 +642,7 @@ def test_defcals():
     ).strip()
     assert (
         dumps(
-            prog.defcals[(("$1", "$2"), "xy", ("angle[32] theta", "float[64] phi"))], indent="    "
+            prog.defcals[(("$1", "$2"), "xy", ("angle[32] theta", "float[64] phi", "10"))], indent="    "
         ).strip()
         == expect_defcal_xy_theta_phi
     )

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 from openpulse.printer import dumps
 
+import oqpy
 from oqpy import *
 from oqpy.base import expr_matches
 from oqpy.quantum_types import PhysicalQubits
@@ -506,6 +507,55 @@ def test_set_shift_frequency():
     assert prog.to_qasm() == expected
 
 
+def test_defcals():
+    prog = Program()
+    constant = declare_waveform_generator("constant", [("length", duration), ("iq", complex128)])
+
+    q_port = PortVar("q_port")
+    rx_port = PortVar("rx_port")
+    tx_port = PortVar("tx_port")
+    q_frame = FrameVar(q_port, 6.431e9, name="q_frame")
+    rx_frame = FrameVar(rx_port, 5.752e9, name="rx_frame")
+    tx_frame = FrameVar(tx_port, 5.752e9, name="tx_frame")
+
+    q2 = PhysicalQubits[2]
+
+    with defcal(prog, q2, "x"):
+        prog.play(q_frame, constant(1e-6, 0.1))
+
+    with defcal(prog, q2, "readout", return_type=oqpy.bit):
+        prog.play(tx_frame, constant(2.4e-6, 0.2))
+        prog.capture(rx_frame, constant(2.4e-6, 1))
+
+    with pytest.raises(AssertionError):
+
+        with defcal(prog, q2, "readout", return_type=bool):
+            prog.play(tx_frame, constant(2.4e-6, 0.2))
+            prog.capture(rx_frame, constant(2.4e-6, 1))
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        extern constant(duration, complex[float[64]]) -> waveform;
+        port rx_port;
+        port tx_port;
+        port q_port;
+        frame q_frame = newframe(q_port, 6431000000.0, 0);
+        frame tx_frame = newframe(tx_port, 5752000000.0, 0);
+        frame rx_frame = newframe(rx_port, 5752000000.0, 0);
+        defcal x $2 {
+            play(q_frame, constant(1000.0ns, 0.1));
+        }
+        defcal readout $2 -> bit {
+            play(tx_frame, constant(2400.0ns, 0.2));
+            capture(rx_frame, constant(2400.0ns, 1));
+        }
+        """
+    ).strip()
+
+    assert prog.to_qasm() == expected
+
+
 def test_ramsey_example():
     prog = Program()
     constant = declare_waveform_generator("constant", [("length", duration), ("iq", complex128)])
@@ -620,8 +670,10 @@ def test_ramsey_example():
     ).strip()
 
     assert prog.to_qasm() == expected
-    assert dumps(prog.defcals[(("$2",), "x90")], indent="    ").strip() == expect_defcal_x90_q2
-    assert dumps(prog.defcals[(("$2",), "readout")], indent="    ").strip() == expect_defcal_readout_q2
+    assert dumps(prog.defcals[(("$2",), "x90", ())], indent="    ").strip() == expect_defcal_x90_q2
+    assert (
+        dumps(prog.defcals[(("$2",), "readout", ())], indent="    ").strip() == expect_defcal_readout_q2
+    )
 
 
 def test_rabi_example():
@@ -748,11 +800,11 @@ def test_program_add():
     ).strip()
 
     assert (
-        dumps(prog2.defcals[(("$1", "$2"), "two_qubit_gate")], indent="    ").strip()
+        dumps(prog2.defcals[(("$1", "$2"), "two_qubit_gate", ())], indent="    ").strip()
         == expected_defcal_two_qubit_gate
     )
     assert (
-        dumps(prog.defcals[(("$1", "$2"), "two_qubit_gate")], indent="    ").strip()
+        dumps(prog.defcals[(("$1", "$2"), "two_qubit_gate", ())], indent="    ").strip()
         == expected_defcal_two_qubit_gate
     )
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -537,7 +537,7 @@ def test_defcals():
     with defcal(prog, q2, "rx", [pi / 3]):
         prog.play(q_frame, constant(1e-6, 0.1))
 
-    with defcal(prog, [q1, q2], "xy", [AngleVar(name="theta"), -pi / 2]) as theta:
+    with defcal(prog, [q1, q2], "xy", [AngleVar(name="theta"), +pi / 2]) as theta:
         prog.increment(theta, 0.1)
         prog.play(q_frame, constant(1e-6, 0.1))
 
@@ -577,7 +577,7 @@ def test_defcals():
         defcal rx(pi / 3) $2 {
             play(q_frame, constant(1000.0ns, 0.1));
         }
-        defcal xy(angle[32] theta, -pi / 2) $1, $2 {
+        defcal xy(angle[32] theta, pi / 2) $1, $2 {
             theta += 0.1;
             play(q_frame, constant(1000.0ns, 0.1));
         }
@@ -619,7 +619,7 @@ def test_defcals():
     )
     expect_defcal_xy_theta_pio2 = textwrap.dedent(
         """
-        defcal xy(angle[32] theta, -pi / 2) $1, $2 {
+        defcal xy(angle[32] theta, pi / 2) $1, $2 {
             theta += 0.1;
             play(q_frame, constant(1000.0ns, 0.1));
         }
@@ -627,7 +627,7 @@ def test_defcals():
     ).strip()
     assert (
         dumps(
-            prog.defcals[(("$1", "$2"), "xy", ("angle[32] theta", "-pi / 2"))], indent="    "
+            prog.defcals[(("$1", "$2"), "xy", ("angle[32] theta", "pi / 2"))], indent="    "
         ).strip()
         == expect_defcal_xy_theta_pio2
     )

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -189,10 +189,10 @@ def test_binary_expressions():
     i = IntVar(5, "i")
     j = IntVar(2, "j")
     prog.set(i, 2 * (i + j))
-    prog.set(j, 2 % (2 + i) % 2)
-    prog.set(j, oqpy.pi)
+    prog.set(j, 2 % (2 - i) % 2)
+    prog.set(j, 1 + oqpy.pi)
     prog.set(j, 1 / oqpy.pi**2 / 2 + 2**oqpy.pi)
-    prog.set(j, -oqpy.pi * oqpy.pi + i**j)
+    prog.set(j, -oqpy.pi * oqpy.pi - i**j)
 
     expected = textwrap.dedent(
         """
@@ -200,10 +200,10 @@ def test_binary_expressions():
         int[32] i = 5;
         int[32] j = 2;
         i = 2 * (i + j);
-        j = 2 % (2 + i) % 2;
-        j = pi;
+        j = 2 % (2 - i) % 2;
+        j = 1 + pi;
         j = 1 / pi ** 2 / 2 + 2 ** pi;
-        j = -pi * pi + i ** j;
+        j = -pi * pi - i ** j;
         """
     ).strip()
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -191,8 +191,8 @@ def test_binary_expressions():
     prog.set(i, 2 * (i + j))
     prog.set(j, 2 % (2 + i) % 2)
     prog.set(j, oqpy.pi)
-    prog.set(j, oqpy.pi / 2)
-    prog.set(j, -oqpy.pi * oqpy.pi + i)
+    prog.set(j, 1 / oqpy.pi**2 / 2 + 2**oqpy.pi)
+    prog.set(j, -oqpy.pi * oqpy.pi + i**j)
 
     expected = textwrap.dedent(
         """
@@ -202,8 +202,8 @@ def test_binary_expressions():
         i = 2 * (i + j);
         j = 2 % (2 + i) % 2;
         j = pi;
-        j = pi / 2;
-        j = -pi * pi + i;
+        j = 1 / pi ** 2 / 2 + 2 ** pi;
+        j = -pi * pi + i ** j;
         """
     ).strip()
 
@@ -642,7 +642,8 @@ def test_defcals():
     ).strip()
     assert (
         dumps(
-            prog.defcals[(("$1", "$2"), "xy", ("angle[32] theta", "float[64] phi", "10"))], indent="    "
+            prog.defcals[(("$1", "$2"), "xy", ("angle[32] theta", "float[64] phi", "10"))],
+            indent="    ",
         ).strip()
         == expect_defcal_xy_theta_phi
     )


### PR DESCRIPTION
The PR adds support for arguments and return type in defcal. 

Arguments are provided via a list of ASTConvertible. Classical variables are passed to the defcal block through the context manager.  

Return types are ast.ClassicalType or OQpy types. 

The keys of the self.defcal dict have been modified to include a tuple of arguments.

Closes #7