### PR TITLE
Add support for arrays

### DIFF
--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -319,13 +319,13 @@ class ArrayVar(_ClassicalVar):
 
     type_cls = ast.ArrayType
     dimensions: list[int]
-    base_type: type[_SizedVar | DurationVar | BoolVar]
+    base_type: type[_SizedVar | DurationVar | BoolVar | ComplexVar]
 
     def __init__(
         self,
         *args: Any,
         dimensions: list[int],
-        base_type: type[_SizedVar | DurationVar | BoolVar] = IntVar,
+        base_type: type[_SizedVar | DurationVar | BoolVar | ComplexVar] = IntVar,
         **kwargs: Any,
     ) -> None:
         self.dimensions = dimensions
@@ -337,6 +337,8 @@ class ArrayVar(_ClassicalVar):
             array_base_type = base_type_instance.type_cls(
                 size=ast.IntegerLiteral(base_type_instance.size)
             )
+        elif isinstance(base_type_instance, ComplexVar):
+            array_base_type = base_type_instance.type_cls(base_type=ast.FloatType())
         else:
             array_base_type = base_type_instance.type_cls()
 
@@ -355,7 +357,7 @@ class ArrayVar(_ClassicalVar):
         return OQIndexExpression(collection=self, index=index)
 
 
-class OQIndexExpression(OQPyExpression):
+class OQIndexExpression(_ClassicalVar, OQPyExpression):
     """An oqpy expression corresponding to an index expression."""
 
     def __init__(self, collection: AstConvertible, index: AstConvertible):

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -351,6 +351,25 @@ class ArrayVar(_ClassicalVar):
             base_type=array_base_type,
         )
 
+    def __getitem__(self, index: AstConvertible) -> OQIndexExpression:
+        return OQIndexExpression(collection=self, index=index)
+
+
+class OQIndexExpression(OQPyExpression):
+    """An oqpy expression corresponding to an index expression."""
+
+    def __init__(self, collection: AstConvertible, index: AstConvertible):
+        self.collection = collection
+        self.index = index
+
+        if isinstance(collection, ArrayVar):
+            self.type = collection.base_type().type_cls()
+
+    def to_ast(self, program: Program) -> ast.IndexExpression:
+        return ast.IndexExpression(
+            collection=to_ast(program, self.collection), index=[to_ast(program, self.index)]
+        )
+
 
 class OQFunctionCall(OQPyExpression):
     """An oqpy expression corresponding to a function call."""

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -314,7 +314,7 @@ class StretchVar(_ClassicalVar):
     type_cls = ast.StretchType
 
 
-AllowedArrayTypes = _SizedVar | DurationVar | BoolVar | ComplexVar
+AllowedArrayTypes = Union[_SizedVar, DurationVar, BoolVar, ComplexVar]
 
 
 class ArrayVar(_ClassicalVar):

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -383,6 +383,7 @@ class OQIndexExpression(OQPyExpression):
             self.type = collection.base_type().type_cls()
 
     def to_ast(self, program: Program) -> ast.IndexExpression:
+        """Converts this oqpy index expression into an ast node."""
         return ast.IndexExpression(
             collection=to_ast(program, self.collection), index=[to_ast(program, self.index)]
         )

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -49,6 +49,7 @@ __all__ = [
     "ComplexVar",
     "DurationVar",
     "OQFunctionCall",
+    "OQIndexExpression",
     "StretchVar",
     "_ClassicalVar",
     "duration",
@@ -327,7 +328,7 @@ class ArrayVar(_ClassicalVar):
     def __class_getitem__(
         cls, item: tuple[type[AllowedArrayTypes], int] | type[AllowedArrayTypes]
     ) -> Callable[..., ArrayVar]:
-        # Allows usage like ArrayVar[oqpy.float64, 32](...) or ArrayVar[oqpy.float64]
+        # Allows usage like ArrayVar[FloatVar, 32](...) or ArrayVar[FloatVar]
         if isinstance(item, tuple):
             base_type = item[0]
             dimensions = list(item[1:])

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -371,7 +371,7 @@ class ArrayVar(_ClassicalVar):
         return OQIndexExpression(collection=self, index=index)
 
 
-class OQIndexExpression(_ClassicalVar, OQPyExpression):
+class OQIndexExpression(OQPyExpression):
     """An oqpy expression corresponding to an index expression."""
 
     def __init__(self, collection: AstConvertible, index: AstConvertible):

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -274,18 +274,20 @@ class ComplexVar(_ClassicalVar):
     """An oqpy variable with bit type."""
 
     type_cls = ast.ComplexType
+    base_type: ast.FloatType = float64
 
-    def __class_getitem__(cls, item: Type[ast.FloatType]) -> Callable[..., ComplexVar]:
+    def __class_getitem__(cls, item: ast.FloatType) -> Callable[..., ComplexVar]:
         return functools.partial(cls, base_type=item)
 
     def __init__(
         self,
         init_expression: AstConvertible | None = None,
         *args: Any,
-        base_type: Type[ast.FloatType] = float64,
+        base_type: ast.FloatType = float64,
         **kwargs: Any,
     ) -> None:
         assert isinstance(base_type, ast.FloatType)
+        self.base_type = base_type
 
         if not isinstance(init_expression, (complex, type(None), OQPyExpression)):
             init_expression = complex(init_expression)  # type: ignore[arg-type]
@@ -353,7 +355,7 @@ class ArrayVar(_ClassicalVar):
                 size=ast.IntegerLiteral(base_type_instance.size)
             )
         elif isinstance(base_type_instance, ComplexVar):
-            array_base_type = base_type_instance.type_cls(base_type=ast.FloatType())
+            array_base_type = base_type_instance.type_cls(base_type=base_type_instance.base_type)
         else:
             array_base_type = base_type_instance.type_cls()
 

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -459,7 +459,11 @@ class Program:
             )
         )
 
-    def set(self, var: classical_types._ClassicalVar, value: AstConvertible) -> Program:
+    def set(
+        self,
+        var: classical_types._ClassicalVar | classical_types.OQIndexExpression,
+        value: AstConvertible,
+    ) -> Program:
         """Set a variable value."""
         self._do_assignment(var, "=", value)
         return self

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -155,10 +155,15 @@ def test_array_declaration():
 
     prog = oqpy.Program(version=None)
     prog.declare(vars)
-    prog.set(i[1], 0)
+    prog.set(i[1], 0) # Set with literal values
+    idx = IntVar(name="idx", init_expression=5)
+    val = IntVar(name="val", init_expression=10)
+    prog.set(i[idx], val)
 
     expected = textwrap.dedent(
         """
+        int[32] idx = 5;
+        int[32] val = 10;
         array[bool, 2] b = {true, false};
         array[int[32], 5] i = {0, 1, 2, 3, 4};
         array[int[55], 5] i55 = {0, 1, 2, 3, 4};
@@ -171,6 +176,7 @@ def test_array_declaration():
         array[float[64], 5] no_init;
         array[float[32], 3, 2] multiDim = {{1.1, 1.2}, {2.1, 2.2}, {3.1, 3.2}};
         i[1] = 0;
+        i[idx] = val;
         """
     ).strip()
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -147,8 +147,11 @@ def test_array_declaration():
     y = ArrayVar(name="y", init_expression=[0.0, 1.0, 2.0, 3.0], dimensions=[4], base_type=FloatVar)
     ang = ArrayVar(name="ang", init_expression=[0.0, 1.0, 2.0, 3.0], dimensions=[4], base_type=AngleVar)
     comp = ArrayVar(name="comp", init_expression=[0, 1 + 1j], dimensions=[2], base_type=ComplexVar)
+    ang_partial = ArrayVar[AngleVar, 2](name="ang_part", init_expression=[oqpy.pi, oqpy.pi/2])
+    simple = ArrayVar[FloatVar](name="no_init", dimensions=[5])
+    multidim = ArrayVar[FloatVar[32], 3, 2](name="multiDim", init_expression=[[1.1, 1.2], [2.1, 2.2], [3.1, 3.2]])
 
-    vars = [b, i, i55, u, x, y, ang, comp]
+    vars = [b, i, i55, u, x, y, ang, comp, ang_partial, simple, multidim]
 
     prog = oqpy.Program(version=None)
     prog.declare(vars)
@@ -164,6 +167,9 @@ def test_array_declaration():
         array[float[64], 4] y = {0.0, 1.0, 2.0, 3.0};
         array[angle[32], 4] ang = {0.0, 1.0, 2.0, 3.0};
         array[complex[float], 2] comp = {0, 1.0 + 1.0im};
+        array[angle[32], 2] ang_part = {pi, pi / 2};
+        array[float[64], 5] no_init;
+        array[float[32], 3, 2] multiDim = {{1.1, 1.2}, {2.1, 2.2}, {3.1, 3.2}};
         i[1] = 0;
         """
     ).strip()

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -138,6 +138,38 @@ def test_complex_numbers_declaration():
 
     assert prog.to_qasm() == expected
 
+def test_array_declaration():
+    b = ArrayVar(name="b", init_expression=[True, False], dimensions=[2], base_type=BoolVar)
+    i = ArrayVar(name="i", init_expression=[0, 1, 2, 3, 4], dimensions=[5], base_type=IntVar)
+    i55 = ArrayVar(name="i55", init_expression=[0, 1, 2, 3, 4], dimensions=[5], base_type=IntVar[55])
+    u = ArrayVar(name="u", init_expression=[0, 1, 2, 3, 4], dimensions=[5], base_type=UintVar)
+    x = ArrayVar(name="x", init_expression=[0e-9, 1e-9, 2e-9], dimensions=[3], base_type=DurationVar)
+    y = ArrayVar(name="y", init_expression=[0.0, 1.0, 2.0, 3.0], dimensions=[4], base_type=FloatVar)
+    ang = ArrayVar(name="ang", init_expression=[0.0, 1.0, 2.0, 3.0], dimensions=[4], base_type=AngleVar)
+    comp = ArrayVar(name="comp", init_expression=[0, 1 + 1j], dimensions=[2], base_type=ComplexVar)
+
+    vars = [b, i, i55, u, x, y, ang, comp]
+
+    prog = oqpy.Program(version=None)
+    prog.declare(vars)
+    prog.set(i[1], 0)
+
+    expected = textwrap.dedent(
+        """
+        array[bool, 2] b = {true, false};
+        array[int[32], 5] i = {0, 1, 2, 3, 4};
+        array[int[55], 5] i55 = {0, 1, 2, 3, 4};
+        array[uint[32], 5] u = {0, 1, 2, 3, 4};
+        array[duration, 3] x = {0.0ns, 1.0ns, 2.0ns};
+        array[float[64], 4] y = {0.0, 1.0, 2.0, 3.0};
+        array[angle[32], 4] ang = {0.0, 1.0, 2.0, 3.0};
+        array[complex[float], 2] comp = {0, 1.0 + 1.0im};
+        i[1] = 0;
+        """
+    ).strip()
+
+    assert prog.to_qasm() == expected
+
 
 def test_non_trivial_variable_declaration():
     prog = Program()

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -147,11 +147,12 @@ def test_array_declaration():
     y = ArrayVar(name="y", init_expression=[0.0, 1.0, 2.0, 3.0], dimensions=[4], base_type=FloatVar)
     ang = ArrayVar(name="ang", init_expression=[0.0, 1.0, 2.0, 3.0], dimensions=[4], base_type=AngleVar)
     comp = ArrayVar(name="comp", init_expression=[0, 1 + 1j], dimensions=[2], base_type=ComplexVar)
+    comp55 = ArrayVar(name="comp55", init_expression=[0, 1 + 1j], dimensions=[2], base_type=ComplexVar[float_(55)])
     ang_partial = ArrayVar[AngleVar, 2](name="ang_part", init_expression=[oqpy.pi, oqpy.pi/2])
     simple = ArrayVar[FloatVar](name="no_init", dimensions=[5])
     multidim = ArrayVar[FloatVar[32], 3, 2](name="multiDim", init_expression=[[1.1, 1.2], [2.1, 2.2], [3.1, 3.2]])
 
-    vars = [b, i, i55, u, x, y, ang, comp, ang_partial, simple, multidim]
+    vars = [b, i, i55, u, x, y, ang, comp, comp55, ang_partial, simple, multidim]
 
     prog = oqpy.Program(version=None)
     prog.declare(vars)
@@ -171,7 +172,8 @@ def test_array_declaration():
         array[duration, 3] x = {0.0ns, 1.0ns, 2.0ns};
         array[float[64], 4] y = {0.0, 1.0, 2.0, 3.0};
         array[angle[32], 4] ang = {0.0, 1.0, 2.0, 3.0};
-        array[complex[float], 2] comp = {0, 1.0 + 1.0im};
+        array[complex[float[64]], 2] comp = {0, 1.0 + 1.0im};
+        array[complex[float[55]], 2] comp55 = {0, 1.0 + 1.0im};
         array[angle[32], 2] ang_part = {pi, pi / 2};
         array[float[64], 5] no_init;
         array[float[32], 3, 2] multiDim = {{1.1, 1.2}, {2.1, 2.2}, {3.1, 3.2}};


### PR DESCRIPTION
This PR adds support for native Opqy arrays. Arrays can be defined with an initial expression and can be indexed using any expression that can be converted to an AST expression. 

See added tests for example usage.