### PR TITLE
Add capability to annotate statements

### DIFF
--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -20,7 +20,16 @@ from __future__ import annotations
 import functools
 import random
 import string
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from openpulse import ast
 
@@ -170,12 +179,20 @@ class _ClassicalVar(Var, OQPyExpression):
         init_expression: AstConvertible | None = None,
         name: str | None = None,
         needs_declaration: bool = True,
+        annotations: Sequence[str | tuple[str, str]] = (),
         **type_kwargs: Any,
     ):
         name = name or "".join([random.choice(string.ascii_letters) for _ in range(10)])
         super().__init__(name, needs_declaration=needs_declaration)
         self.type = self.type_cls(**type_kwargs)
         self.init_expression = init_expression
+        self.annotations = []
+        for annotation in annotations:
+            if isinstance(annotation, tuple):
+                keyword, command = annotation
+                self.annotations.append(ast.Annotation(keyword, command))
+            else:
+                self.annotations.append(ast.Annotation(annotation))
 
     def to_ast(self, program: Program) -> ast.Identifier:
         """Converts the OQpy variable into an ast node."""
@@ -185,7 +202,9 @@ class _ClassicalVar(Var, OQPyExpression):
     def make_declaration_statement(self, program: Program) -> ast.Statement:
         """Make an ast statement that declares the OQpy variable."""
         init_expression_ast = optional_ast(program, self.init_expression)
-        return ast.ClassicalDeclaration(self.type, self.to_ast(program), init_expression_ast)
+        stmt = ast.ClassicalDeclaration(self.type, self.to_ast(program), init_expression_ast)
+        stmt.annotations = self.annotations
+        return stmt
 
 
 class BoolVar(_ClassicalVar):

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -23,6 +23,7 @@ AST components), and the class has methods which add to the current state.
 
 from __future__ import annotations
 
+import warnings
 from copy import deepcopy
 from typing import Any, Iterable, Iterator, Optional
 
@@ -56,6 +57,7 @@ class ProgramState:
     def __init__(self) -> None:
         self.body: list[ast.Statement] = []
         self.if_clause: Optional[ast.BranchingStatement] = None
+        self.annotations: list[ast.Annotation] = []
 
     def add_if_clause(self, condition: ast.Expression, if_clause: list[ast.Statement]) -> None:
         self.finalize_if_clause()
@@ -73,7 +75,11 @@ class ProgramState:
             self.add_statement(if_clause)
 
     def add_statement(self, stmt: ast.Statement) -> None:
+        assert isinstance(stmt, ast.Statement)
         self.finalize_if_clause()
+        if self.annotations:
+            stmt.annotations.extend(self.annotations)
+            self.annotations = []
         self.body.append(stmt)
 
 
@@ -149,6 +155,8 @@ class Program:
         """Close a context by removing the program state from the top stack, and return it."""
         state = self.stack.pop()
         state.finalize_if_clause()
+        if state.annotations:
+            warnings.warn(f"Annotation(s) {state.annotations} not applied to any statement")
         return state
 
     def _add_var(self, var: Var) -> None:
@@ -259,6 +267,8 @@ class Program:
 
         assert len(self.stack) == 1
         self._state.finalize_if_clause()
+        if self._state.annotations:
+            warnings.warn(f"Annotation(s) {self._state.annotations} not applied to any statement")
         statements = []
         if include_externs:
             statements += self._make_externs_statements(encal_declarations)
@@ -459,6 +469,11 @@ class Program:
             )
         )
 
+    def do_expression(self, expression: AstConvertible) -> Program:
+        """Add a statement which evaluates a given expression without assigning the output."""
+        self._add_statement(ast.ExpressionStatement(to_ast(self, expression)))
+        return self
+
     def set(
         self,
         var: classical_types._ClassicalVar | classical_types.OQIndexExpression,
@@ -482,6 +497,11 @@ class Program:
         """In-place update of a variable to be itself modulo value."""
         assert isinstance(var, classical_types.IntVar)
         self._do_assignment(var, "%=", value)
+        return self
+
+    def annotate(self, keyword: str, command: Optional[str] = None) -> Program:
+        """Add an annotation to the next statement."""
+        self._state.annotations.append(ast.Annotation(keyword, command))
         return self
 
 

--- a/oqpy/pulse.py
+++ b/oqpy/pulse.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Sequence
 
 from openpulse import ast
 
@@ -67,6 +67,7 @@ class FrameVar(_ClassicalVar):
         phase: AstConvertible = 0,
         name: str | None = None,
         needs_declaration: bool = True,
+        annotations: Sequence[str | tuple[str, str]] = (),
     ):
         if (port is None) != (frequency is None):
             raise ValueError("Must declare both port and frequency or neither.")
@@ -75,4 +76,6 @@ class FrameVar(_ClassicalVar):
         else:
             assert frequency is not None
             init_expression = OQFunctionCall("newframe", [port, frequency, phase], ast.FrameType)
-        super().__init__(init_expression, name, needs_declaration=needs_declaration)
+        super().__init__(
+            init_expression, name, needs_declaration=needs_declaration, annotations=annotations
+        )

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -138,25 +138,36 @@ def test_complex_numbers_declaration():
 
     assert prog.to_qasm() == expected
 
+
 def test_array_declaration():
     b = ArrayVar(name="b", init_expression=[True, False], dimensions=[2], base_type=BoolVar)
     i = ArrayVar(name="i", init_expression=[0, 1, 2, 3, 4], dimensions=[5], base_type=IntVar)
-    i55 = ArrayVar(name="i55", init_expression=[0, 1, 2, 3, 4], dimensions=[5], base_type=IntVar[55])
+    i55 = ArrayVar(
+        name="i55", init_expression=[0, 1, 2, 3, 4], dimensions=[5], base_type=IntVar[55]
+    )
     u = ArrayVar(name="u", init_expression=[0, 1, 2, 3, 4], dimensions=[5], base_type=UintVar)
-    x = ArrayVar(name="x", init_expression=[0e-9, 1e-9, 2e-9], dimensions=[3], base_type=DurationVar)
+    x = ArrayVar(
+        name="x", init_expression=[0e-9, 1e-9, 2e-9], dimensions=[3], base_type=DurationVar
+    )
     y = ArrayVar(name="y", init_expression=[0.0, 1.0, 2.0, 3.0], dimensions=[4], base_type=FloatVar)
-    ang = ArrayVar(name="ang", init_expression=[0.0, 1.0, 2.0, 3.0], dimensions=[4], base_type=AngleVar)
+    ang = ArrayVar(
+        name="ang", init_expression=[0.0, 1.0, 2.0, 3.0], dimensions=[4], base_type=AngleVar
+    )
     comp = ArrayVar(name="comp", init_expression=[0, 1 + 1j], dimensions=[2], base_type=ComplexVar)
-    comp55 = ArrayVar(name="comp55", init_expression=[0, 1 + 1j], dimensions=[2], base_type=ComplexVar[float_(55)])
-    ang_partial = ArrayVar[AngleVar, 2](name="ang_part", init_expression=[oqpy.pi, oqpy.pi/2])
+    comp55 = ArrayVar(
+        name="comp55", init_expression=[0, 1 + 1j], dimensions=[2], base_type=ComplexVar[float_(55)]
+    )
+    ang_partial = ArrayVar[AngleVar, 2](name="ang_part", init_expression=[oqpy.pi, oqpy.pi / 2])
     simple = ArrayVar[FloatVar](name="no_init", dimensions=[5])
-    multidim = ArrayVar[FloatVar[32], 3, 2](name="multiDim", init_expression=[[1.1, 1.2], [2.1, 2.2], [3.1, 3.2]])
+    multidim = ArrayVar[FloatVar[32], 3, 2](
+        name="multiDim", init_expression=[[1.1, 1.2], [2.1, 2.2], [3.1, 3.2]]
+    )
 
     vars = [b, i, i55, u, x, y, ang, comp, comp55, ang_partial, simple, multidim]
 
     prog = oqpy.Program(version=None)
     prog.declare(vars)
-    prog.set(i[1], 0) # Set with literal values
+    prog.set(i[1], 0)  # Set with literal values
     idx = IntVar(name="idx", init_expression=5)
     val = IntVar(name="val", init_expression=10)
     prog.set(i[idx], val)
@@ -184,16 +195,17 @@ def test_array_declaration():
 
     assert prog.to_qasm() == expected
 
+
 def test_non_trivial_array_access():
     prog = oqpy.Program()
     port = oqpy.PortVar(name="my_port")
     frame = oqpy.FrameVar(name="my_frame", port=port, frequency=1e9, phase=0)
 
     zero_to_one = oqpy.ArrayVar(
-        name='duration_array',
+        name="duration_array",
         init_expression=[0.0, 0.25, 0.5, 0.75, 1],
         dimensions=[5],
-        base_type=oqpy.DurationVar
+        base_type=oqpy.DurationVar,
     )
     one_second = oqpy.DurationVar(init_expression=1, name="one_second")
 
@@ -219,6 +231,7 @@ def test_non_trivial_array_access():
     ).strip()
 
     assert prog.to_qasm() == expected
+
 
 def test_non_trivial_variable_declaration():
     prog = Program()
@@ -519,7 +532,9 @@ def test_for_in_var_types():
     # Test indexing over an ArrayVar
     program = oqpy.Program()
     pyphases = [0] + [oqpy.pi / i for i in range(10, 1, -2)]
-    phases = ArrayVar(name="phases", dimensions=[len(pyphases)], init_expression=pyphases, base_type=AngleVar)
+    phases = ArrayVar(
+        name="phases", dimensions=[len(pyphases)], init_expression=pyphases, base_type=AngleVar
+    )
 
     with oqpy.ForIn(program, range(len(pyphases)), "idx") as idx:
         program.shift_phase(phases[idx], frame)
@@ -534,7 +549,7 @@ def test_for_in_var_types():
             shift_phase(phases[idx], my_frame);
         }
         """
-        ).strip()
+    ).strip()
 
     assert program.to_qasm() == expected
 
@@ -606,7 +621,7 @@ def test_subroutine_with_return():
         prog.delay(50e-9, q)
 
     q = PhysicalQubits[0]
-    delay50ns(prog, q)
+    prog.do_expression(delay50ns(prog, q))
 
     with pytest.raises(ValueError):
 
@@ -638,8 +653,12 @@ def test_subroutine_with_return():
         def multiply(int[32] x, int[32] y) -> int[32] {
             return x * y;
         }
+        def delay50ns(qubit q) {
+            delay[50.0ns] q;
+        }
         int[32] y = 2;
         y = multiply(y, 3);
+        delay50ns($0);
         """
     ).strip()
 
@@ -1337,6 +1356,79 @@ def test_discrete_waveform():
     ).strip()
 
     assert prog.to_qasm() == expected
+
+
+def test_annotate():
+    prog = Program()
+    gaussian = declare_waveform_generator(
+        "gaussian",
+        [("length", duration), ("sigma", duration), ("amplitude", float64), ("phase", float64)],
+    )
+
+    zcu216_dac231_0 = PortVar(
+        "zcu216_dac231_0", annotations=["makeport", ("some_keyword", "some_command")]
+    )
+    q0_transmon_xy_frame = FrameVar(
+        zcu216_dac231_0, 3911851971.26885, name="q0_transmon_xy_frame", annotations=["makeframe"]
+    )
+    rabi_pulse_wf = WaveformVar(
+        gaussian(5.2e-8, 1.3e-8, 1.0, 0.0), "rabi_pulse_wf", annotations=["makepulse"]
+    )
+
+    i = IntVar(0, name="i", annotations=["some-int"])
+
+    @annotate_subroutine("inline")
+    @annotate_subroutine("optimize", "-O3")
+    @subroutine
+    def f(prog: Program, x: IntVar) -> IntVar:
+        return x
+
+    prog.annotate("first-invocation")
+    prog.do_expression(f(prog, i))
+
+    prog.annotate("make-for-loop", "with additional info")
+    with ForIn(prog, range(1, 1001), "shot") as shot:
+        prog.annotate("make-set-scale")
+        prog.set_scale(q0_transmon_xy_frame, -0.2)
+        prog.play(q0_transmon_xy_frame, rabi_pulse_wf)
+
+    prog.annotate("second-invocation")
+    prog.set(i, f(prog, i))
+
+    # todo: Fix printer for indentation of annotations
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        defcalgrammar "openpulse";
+        @inline
+        @optimize -O3
+        def f(int[32] x) -> int[32] {
+            return x;
+        }
+        cal {
+        @makeport
+        @some_keyword some_command
+            port zcu216_dac231_0;
+        @makeframe
+            frame q0_transmon_xy_frame = newframe(zcu216_dac231_0, 3911851971.26885, 0);
+        @makepulse
+            waveform rabi_pulse_wf = gaussian(52.0ns, 13.0ns, 1.0, 0.0);
+        }
+        @some-int
+        int[32] i = 0;
+        @first-invocation
+        f(i);
+        @make-for-loop with additional info
+        for int shot in [1:1000] {
+        @make-set-scale
+            set_scale(q0_transmon_xy_frame, -0.2);
+            play(q0_transmon_xy_frame, rabi_pulse_wf);
+        }
+        @second-invocation
+        i = f(i);
+        """
+    ).strip()
+    assert prog.to_qasm(include_externs=False, encal_declarations=True) == expected
 
 
 def test_var_and_expr_matches():


### PR DESCRIPTION
This adds support for openqasm [annotations](https://openqasm.com/language/directives.html#annotations)

Annotations can be added in three ways:

1. `Program.annotate` which attaches the annotation to the next statement added to the program
2. `_ClassicalVar(..., annotations=[...])`, which attaches the annotation to the variable declaration statement 
3. `@annotate_subroutine(...)` decorator, which attaches the annotation to the subroutine declaration