### PR TITLE
Fix expressions with duration literals

### DIFF
--- a/oqpy/timing.py
+++ b/oqpy/timing.py
@@ -63,6 +63,7 @@ class OQDurationLiteral(OQPyExpression):
     def __init__(self, duration: float) -> None:
         super().__init__()
         self.duration = duration
+        self.type = ast.DurationLiteral
 
     def to_ast(self, program: Program) -> ast.DurationLiteral:
         # Todo (#53): make better units?

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -283,9 +283,11 @@ def test_binary_expressions():
     i = IntVar(5, "i")
     j = IntVar(2, "j")
     k = IntVar(0, "k")
+    f = FloatVar(0.0, "f")
     b1 = BoolVar(False, "b1")
     b2 = BoolVar(True, "b2")
     b3 = BoolVar(False, "b3")
+    d = DurationVar(5e-9, "d")
     prog.set(i, 2 * (i + j))
     prog.set(j, 2 % (2 - i) % 2)
     prog.set(j, 1 + oqpy.pi)
@@ -310,6 +312,8 @@ def test_binary_expressions():
     prog.set(b1, logical_or(b2, b3))
     prog.set(b1, logical_and(b2, True))
     prog.set(b1, logical_or(False, b3))
+    prog.set(d, d + make_duration(10e-9))
+    prog.set(f, d / make_duration(1))
 
     expected = textwrap.dedent(
         """
@@ -320,6 +324,8 @@ def test_binary_expressions():
         bool b1 = false;
         bool b2 = true;
         bool b3 = false;
+        duration d = 5.0ns;
+        float[64] f = 0.0;
         i = 2 * (i + j);
         j = 2 % (2 - i) % 2;
         j = 1 + pi;
@@ -344,6 +350,8 @@ def test_binary_expressions():
         b1 = b2 || b3;
         b1 = b2 && true;
         b1 = false || b3;
+        d = d + 10.0ns;
+        f = d / 1000000000.0ns;
         """
     ).strip()
 
@@ -1550,6 +1558,31 @@ def test_program_tracks_frame_waveform_vars():
 
     assert expr_matches(list(prog.frame_vars), [f1, f3, f2])
     assert expr_matches(list(prog.waveform_vars), [constant_wf, discrete_wf])
+
+
+def test_duration_literal_arithmetic():
+    # Test that duration literals can be used as a part of expression.
+    port = oqpy.PortVar("myport")
+    frame = oqpy.FrameVar(port, 1e9, name="myframe")
+    delay_time = oqpy.make_duration(50e-9)  # 50 ns
+    one_second = oqpy.make_duration(1)  # 1 second
+    delay_repetition = 10
+
+    program = oqpy.Program()
+    program.delay(delay_repetition * delay_time, frame)
+    program.shift_phase(frame, 2 * oqpy.pi * (delay_time / one_second))
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        port myport;
+        frame myframe = newframe(myport, 1000000000.0, 0);
+        delay[10 * 50.0ns] myframe;
+        shift_phase(myframe, 2 * pi * (50.0ns / 1000000000.0ns));
+        """
+    ).strip()
+
+    assert program.to_qasm() == expected
 
 
 def test_make_duration():


### PR DESCRIPTION
Duration literals are missing a type which causes errors when trying to build expressions with them. For example, this code

```python
import oqpy

port = oqpy.PortVar("myport")
frame = oqpy.FrameVar(port, 1e9, name="myframe")
delay_time = oqpy.make_duration(50e-9) # 50 ns
delay_repetition = 10

program = oqpy.Program()
program.delay(delay_repetition * delay_time, frame)
```

errors out and print
```
AttributeError                            Traceback (most recent call last)
Cell In[2], line 9
      6 delay_repetition = 10
      8 program = oqpy.Program()
----> 9 program.delay(delay_repetition * delay_time, frame)

File ~/Work/oqpy/oqpy/base.py:96, in OQPyExpression.__rmul__(self, other)
     95 def __rmul__(self, other: AstConvertible) -> OQPyBinaryExpression:
---> 96     return self._to_binary("*", other, self)

File ~/Work/oqpy/oqpy/base.py:61, in OQPyExpression._to_binary(op_name, first, second)
     56 @staticmethod
     57 def _to_binary(
     58     op_name: str, first: AstConvertible, second: AstConvertible
     59 ) -> OQPyBinaryExpression:
     60     """Helper method to produce a binary expression."""
---> 61     return OQPyBinaryExpression(ast.BinaryOperator[op_name], first, second)

File ~/Work/oqpy/oqpy/base.py:237, in OQPyBinaryExpression.__init__(self, op, lhs, rhs)
    235     self.type = lhs.type
    236 elif isinstance(rhs, OQPyExpression):
--> 237     self.type = rhs.type
    238 else:
    239     raise TypeError("Neither lhs nor rhs is an expression?")

AttributeError: 'OQDurationLiteral' object has no attribute 'type'
```

Adding the proper type fixes the issue. I have also added a few tests.