### PR TITLE
Fix initiating duration arrays with numpy array

### DIFF
--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -374,7 +374,7 @@ class ArrayVar(_ClassicalVar):
             array_base_type = base_type_instance.type_cls()
 
         # Automatically handle Duration array.
-        if base_type is DurationVar and kwargs["init_expression"]:
+        if base_type is DurationVar and kwargs["init_expression"] is not None:
             kwargs["init_expression"] = (make_duration(i) for i in kwargs["init_expression"])
 
         super().__init__(

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -163,8 +163,11 @@ def test_array_declaration():
     multidim = ArrayVar[FloatVar[32], 3, 2](
         name="multiDim", init_expression=[[1.1, 1.2], [2.1, 2.2], [3.1, 3.2]]
     )
+    npinit = ArrayVar(
+        name="npinit", init_expression=np.arange(10) * 1e-9, dimensions=[11], base_type=DurationVar
+    )
 
-    vars = [b, i, i55, u, x, y, ang, comp, comp55, ang_partial, simple, multidim]
+    vars = [b, i, i55, u, x, y, ang, comp, comp55, ang_partial, simple, multidim, npinit]
 
     prog = oqpy.Program(version=None)
     prog.declare(vars)
@@ -189,6 +192,7 @@ def test_array_declaration():
         array[angle[32], 2] ang_part = {pi, pi / 2};
         array[float[64], 5] no_init;
         array[float[32], 3, 2] multiDim = {{1.1, 1.2}, {2.1, 2.2}, {3.1, 3.2}};
+        array[int[32], 11] npinit = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         i[1] = 0;
         i[idx] = val;
         """


### PR DESCRIPTION
Numpy does not supports using a non-empty array as a truth value, causing the following example to fail:

```python
import numpy as np
import oqpy

npduration = oqpy.ArrayVar(
    name="npinit",
    init_expression=np.arange(11) * 1e-9,
    dimensions=[11],
    base_type=oqpy.DurationVar,
)
```

with stack trace
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[3], line 4
      1 import numpy as np
      2 import oqpy
----> 4 npduration = oqpy.ArrayVar(
      5     name="npinit",
      6     init_expression=np.arange(11) * 1e-9,
      7     dimensions=[11],
      8     base_type=oqpy.DurationVar,
      9 )

File ~/Work/oqpy/oqpy/classical_types.py:377, in ArrayVar.__init__(self, dimensions, base_type, *args, **kwargs)
    374     array_base_type = base_type_instance.type_cls()
    376 # Automatically handle Duration array.
--> 377 if base_type is DurationVar and kwargs["init_expression"]:
    378     kwargs["init_expression"] = (make_duration(i) for i in kwargs["init_expression"])
    380 super().__init__(
    381     *args,
    382     **kwargs,
    383     dimensions=[ast.IntegerLiteral(dimension) for dimension in dimensions],
    384     base_type=array_base_type,
    385 )

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Changing the comparison condition fixes this issue. 