### PR TITLE
Promote floats to durations during arithmetic ops

### DIFF
--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -238,6 +238,17 @@ class OQPyBinaryExpression(OQPyExpression):
         else:
             raise TypeError("Neither lhs nor rhs is an expression?")
 
+        # Adding floats to durations is not allowed. So we promote types as necessary.
+        if isinstance(self.type, ast.DurationType) and self.op in [
+            ast.BinaryOperator["+"],
+            ast.BinaryOperator["-"],
+        ]:
+            # Late import to avoid circular imports.
+            from oqpy.timing import make_duration
+
+            self.lhs = make_duration(self.lhs)
+            self.rhs = make_duration(self.rhs)
+
     def to_ast(self, program: Program) -> ast.BinaryExpression:
         """Converts the OQpy expression into an ast node."""
         return ast.BinaryExpression(self.op, to_ast(program, self.lhs), to_ast(program, self.rhs))

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -177,12 +177,16 @@ def test_array_declaration():
     prog.set(i[1], 0)  # Set with literal values
     idx = IntVar(name="idx", init_expression=5)
     val = IntVar(name="val", init_expression=10)
+    d = DurationVar(name="d", init_expression=0)
     prog.set(i[idx], val)
+    prog.set(npinit[5], d - 2e-9)
+    prog.set(npinit[0], 2 * npinit[0] + 2e-9)
 
     expected = textwrap.dedent(
         """
         int[32] idx = 5;
         int[32] val = 10;
+        duration d = 0.0ns;
         array[bool, 2] b = {true, false};
         array[int[32], 5] i = {0, 1, 2, 3, 4};
         array[int[55], 5] i55 = {0, 1, 2, 3, 4};
@@ -198,6 +202,8 @@ def test_array_declaration():
         array[duration, 11] npinit = {0.0ns, 1.0ns, 2.0ns, 4.0ns};
         i[1] = 0;
         i[idx] = val;
+        npinit[5] = d - 2.0ns;
+        npinit[0] = 2 * npinit[0] + 2.0ns;
         """
     ).strip()
 
@@ -320,6 +326,9 @@ def test_binary_expressions():
     prog.set(b1, logical_or(b2, b3))
     prog.set(b1, logical_and(b2, True))
     prog.set(b1, logical_or(False, b3))
+    prog.set(d, d / 5)
+    prog.set(d, d + 5e-9)
+    prog.set(d, 5e-9 - d)
     prog.set(d, d + make_duration(10e-9))
     prog.set(f, d / make_duration(1))
 
@@ -358,6 +367,9 @@ def test_binary_expressions():
         b1 = b2 || b3;
         b1 = b2 && true;
         b1 = false || b3;
+        d = d / 5;
+        d = d + 5.0ns;
+        d = 5.0ns - d;
         d = d + 10.0ns;
         f = d / 1000000000.0ns;
         """


### PR DESCRIPTION
`oqpy` allows adding float literals to durations, but they are not automatically converted to duration literals (unlike initialization of `DurationVar` or duration arrays, where python floating literals are automatically converted to duration literals). 

With this change, literals are automatically promoted. For example,
```python
prog = oqpy.Program()
port = oqpy.PortVar(name="my_port")
frame = oqpy.FrameVar(name="my_frame", port=port, frequency=5e9, phase=0)

prog.delay(delay + 5e-9, frame)
print(prog.to_qasm(encal_declarations=True))
```
will correctly promote `5e-9` to a duration literal and output
```
OPENQASM 3.0;
defcalgrammar "openpulse";
cal {
    port my_port;
    frame my_frame = newframe(my_port, 5000000000.0, 0);
}
duration d = 10.0ns;
delay[d + 5.0ns] my_frame;
```