### PR TITLE
Create oqpy.Range to allow ForIn ranges with expressions.

### DIFF
--- a/oqpy/control_flow.py
+++ b/oqpy/control_flow.py
@@ -145,12 +145,7 @@ class Range:
     instead of just int.
     """
 
-    def __init__(
-        self,
-        start: int | AstConvertible,
-        stop: int | AstConvertible,
-        step: int | AstConvertible = 1,
-    ):
+    def __init__(self, start: AstConvertible, stop: AstConvertible, step: AstConvertible = 1):
         self.start = start
         self.stop = stop
         self.step = step

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -1825,3 +1825,23 @@ def test_constant_conversion():
         """
     ).strip()
     assert prog.to_qasm() == expected
+
+
+def test_oqpy_range():
+    prog = Program()
+    sum = oqpy.IntVar(0, "sum")
+    with ForIn(prog, range(10), "i") as i:
+        with ForIn(prog, oqpy.Range(1, i), "j") as j:
+            prog.increment(sum, j)
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        int[32] sum = 0;
+        for int i in [0:9] {
+            for int j in [1:i - 1] {
+                sum += j;
+            }
+        }
+        """
+    ).strip()
+    assert prog.to_qasm() == expected


### PR DESCRIPTION
Right now it is not possible to create a `ForIn` expression with a RangeDefinition which has a general expression as part of its start/stop/step fields, because this code path is forced to go through the builtin `range` function which only takes integers.

This creates an `oqpy.Range` class which can accept general arguments for start/stop/step.