### PR TITLE
Fix for nested subroutines and if statements in subroutines

### DIFF
--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -97,6 +97,7 @@ def subroutine(
         for input_val in inputs.values():
             inner_prog._mark_var_declared(input_val)
         output = func(inner_prog, **inputs)
+        inner_prog.autodeclare()
         inner_prog._state.finalize_if_clause()
         body = inner_prog._state.body
         if isinstance(output, OQPyExpression):

--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -97,6 +97,7 @@ def subroutine(
         for input_val in inputs.values():
             inner_prog._mark_var_declared(input_val)
         output = func(inner_prog, **inputs)
+        inner_prog._state.finalize_if_clause()
         body = inner_prog._state.body
         if isinstance(output, OQPyExpression):
             return_type = output.type
@@ -115,6 +116,9 @@ def subroutine(
             raise ValueError(
                 "Output type of subroutine {name} was neither oqpy expression nor None."
             )
+        program.defcals.update(inner_prog.defcals)
+        program.subroutines.update(inner_prog.subroutines)
+        program.externs.update(inner_prog.externs)
         stmt = ast.SubroutineDefinition(
             identifier,
             arguments=arguments,


### PR DESCRIPTION
We encountered some errors using subroutines:

- If statements without accompanying else statements were being dropped in the output
- Using subroutines within a subroutine did not cause the inner subroutine definition to be added to the program
- Variables used within a subroutine are not properly autodeclared within that subroutine.