### PR TITLE
Allow externs with no arguments and no return value

### DIFF
--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import math
 import sys
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Iterable, Sequence, Union
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Sequence, Union
 
 import numpy as np
 from openpulse import ast
@@ -50,7 +50,7 @@ class OQPyExpression:
     ``==`` which produces a new expression instead of producing a python boolean.
     """
 
-    type: ast.ClassicalType
+    type: Optional[ast.ClassicalType]
 
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the oqpy expression into an ast node."""
@@ -175,7 +175,7 @@ class OQPyExpression:
         )
 
 
-def _get_type(val: AstConvertible) -> ast.ClassicalType:
+def _get_type(val: AstConvertible) -> Optional[ast.ClassicalType]:
     if isinstance(val, OQPyExpression):
         return val.type
     elif isinstance(val, int):

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -25,6 +25,7 @@ from typing import (
     Any,
     Callable,
     Iterable,
+    Optional,
     Sequence,
     Type,
     TypeVar,
@@ -420,7 +421,7 @@ class OQFunctionCall(OQPyExpression):
         self,
         identifier: Union[str, ast.Identifier],
         args: Iterable[AstConvertible],
-        return_type: ast.ClassicalType,
+        return_type: Optional[ast.ClassicalType],
         extern_decl: ast.ExternDeclaration | None = None,
         subroutine_decl: ast.SubroutineDefinition | None = None,
     ):
@@ -429,7 +430,7 @@ class OQFunctionCall(OQPyExpression):
         Args:
             identifier: The function name.
             args: The function arguments.
-            return_type: The type returned by the function call.
+            return_type: The type returned by the function call. If none, returns nothing.
             extern_decl: An optional extern declaration ast node. If present,
                 this extern declaration will be added to the top of the program
                 whenever this is converted to ast.

--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -180,8 +180,8 @@ def declare_extern(
         program.set(var, sqrt(0.5))
 
     """
-    arg_names = list(zip(*(args)))[0]
-    arg_types = list(zip(*(args)))[1]
+    arg_names = list(zip(*(args)))[0] if args else []
+    arg_types = list(zip(*(args)))[1] if args else []
     extern_decl = ast.ExternDeclaration(
         ast.Identifier(name),
         [ast.ExternArgument(type=t) for t in arg_types],

--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import functools
 import inspect
-from typing import Any, Callable, Sequence, TypeVar, get_type_hints
+from typing import Any, Callable, Optional, Sequence, TypeVar, get_type_hints
 
 from mypy_extensions import VarArg
 from openpulse import ast
@@ -164,7 +164,7 @@ def subroutine(
 def declare_extern(
     name: str,
     args: list[tuple[str, ast.ClassicalType]],
-    return_type: ast.ClassicalType,
+    return_type: Optional[ast.ClassicalType] = None,
     annotations: Sequence[str | tuple[str, str]] = (),
 ) -> Callable[..., OQFunctionCall]:
     """Declare an extern and return a callable which adds the extern.


### PR DESCRIPTION
This pull request proposes two changes:
1. Allow externs that don't accept any arguments. We represent this with an empty list.
2. Allow externs with no return value. We represent [`void`](https://openqasm.com/language/types.html#void-type) return type with python `None`.

On (2), while OpenQASM spec defines a [`void` keyword](https://openqasm.com/language/types.html#void-type), the AST does not expose it anywhere. Using `None` internally is a working compromise.