### PR TITLE
Add oqpy.gate for gate definitions

### DIFF
--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -99,11 +99,13 @@ class Program:
             tuple[tuple[str, ...], str, tuple[str, ...]], ast.CalibrationDefinition
         ] = {}
         self.subroutines: dict[str, ast.SubroutineDefinition] = {}
+        self.gates: dict[str, ast.QuantumGateDefinition] = {}
         self.externs: dict[str, ast.ExternDeclaration] = {}
         self.declared_vars: dict[str, Var] = {}
         self.undeclared_vars: dict[str, Var] = {}
         self.simplify_constants = simplify_constants
         self.declared_subroutines: set[str] = set()
+        self.declared_gates: set[str] = set()
 
         if version is None or (
             len(version.split(".")) in [1, 2]
@@ -125,6 +127,10 @@ class Program:
         for name, subroutine_stmt in other.subroutines.items():
             self._add_subroutine(
                 name, subroutine_stmt, needs_declaration=name not in other.declared_subroutines
+            )
+        for name, gate_stmt in other.gates.items():
+            self._add_gate(
+                name, gate_stmt, needs_declaration=name not in other.declared_gates
             )
         self.externs.update(other.externs)
         for var in other.declared_vars.values():
@@ -221,6 +227,17 @@ class Program:
         if not needs_declaration:
             self.declared_subroutines.add(name)
 
+    def _add_gate(
+        self, name: str, stmt: ast.QuantumGateDefinition, needs_declaration: bool = True
+    ) -> None:
+        """Register a gate definition which has been used.
+
+        Gate definitions are added to the top of the program upon conversion to ast.
+        """
+        self.gates[name] = stmt
+        if not needs_declaration:
+            self.declared_gates.add(name)
+
     def _add_defcal(
         self,
         qubit_names: list[str],
@@ -297,6 +314,10 @@ class Program:
             mutating_prog.subroutines[subroutine_name]
             for subroutine_name in mutating_prog.subroutines
             if subroutine_name not in mutating_prog.declared_subroutines
+        ] + [
+            mutating_prog.gates[gate_name]
+            for gate_name in mutating_prog.gates
+            if gate_name not in mutating_prog.declared_gates
         ] + mutating_prog._state.body
         if encal:
             statements = [ast.CalibrationStatement(statements)]
@@ -362,6 +383,9 @@ class Program:
             if callable(var) and hasattr(var, "subroutine_declaration"):
                 name, stmt = var.subroutine_declaration
                 self._add_subroutine(name, stmt, needs_declaration=False)
+            elif callable(var) and hasattr(var, "gate_declaration"):
+                name, stmt = var.gate_declaration
+                self._add_gate(name, stmt, needs_declaration=False)
             else:
                 stmt = var.make_declaration_statement(self)
                 self._mark_var_declared(var)

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -383,9 +383,6 @@ class Program:
             if callable(var) and hasattr(var, "subroutine_declaration"):
                 name, stmt = var.subroutine_declaration
                 self._add_subroutine(name, stmt, needs_declaration=False)
-            elif callable(var) and hasattr(var, "gate_declaration"):
-                name, stmt = var.gate_declaration
-                self._add_gate(name, stmt, needs_declaration=False)
             else:
                 stmt = var.make_declaration_statement(self)
                 self._mark_var_declared(var)

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -129,9 +129,7 @@ class Program:
                 name, subroutine_stmt, needs_declaration=name not in other.declared_subroutines
             )
         for name, gate_stmt in other.gates.items():
-            self._add_gate(
-                name, gate_stmt, needs_declaration=name not in other.declared_gates
-            )
+            self._add_gate(name, gate_stmt, needs_declaration=name not in other.declared_gates)
         self.externs.update(other.externs)
         for var in other.declared_vars.values():
             self._mark_var_declared(var)
@@ -310,15 +308,19 @@ class Program:
         statements = []
         if include_externs:
             statements += mutating_prog._make_externs_statements(encal_declarations)
-        statements += [
-            mutating_prog.subroutines[subroutine_name]
-            for subroutine_name in mutating_prog.subroutines
-            if subroutine_name not in mutating_prog.declared_subroutines
-        ] + [
-            mutating_prog.gates[gate_name]
-            for gate_name in mutating_prog.gates
-            if gate_name not in mutating_prog.declared_gates
-        ] + mutating_prog._state.body
+        statements += (
+            [
+                mutating_prog.subroutines[subroutine_name]
+                for subroutine_name in mutating_prog.subroutines
+                if subroutine_name not in mutating_prog.declared_subroutines
+            ]
+            + [
+                mutating_prog.gates[gate_name]
+                for gate_name in mutating_prog.gates
+                if gate_name not in mutating_prog.declared_gates
+            ]
+            + mutating_prog._state.body
+        )
         if encal:
             statements = [ast.CalibrationStatement(statements)]
         if encal_declarations:

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -79,6 +79,7 @@ def gate(
     qubits: Union[Qubit, list[Qubit]],
     name: str,
     arguments: Optional[list[AstConvertible]] = None,
+    declare_here: bool = False,
 ) -> Union[Iterator[None], Iterator[list[_ClassicalVar]], Iterator[_ClassicalVar]]:
     """Context manager for creating a gate.
 
@@ -117,7 +118,9 @@ def gate(
         qubits=[ast.Identifier(q.name) for q in qubits],
         body=state.body,
     )
-    program._add_gate(name, stmt)
+    if declare_here:
+        program._add_statement(stmt)
+    program._add_gate(name, stmt, needs_declaration=not declare_here)
 
 
 @contextlib.contextmanager

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -24,7 +24,7 @@ from openpulse import ast
 from openpulse.printer import dumps
 
 from oqpy.base import AstConvertible, Var, make_annotations, to_ast
-from oqpy.classical_types import _ClassicalVar, AngleVar
+from oqpy.classical_types import AngleVar, _ClassicalVar
 
 if TYPE_CHECKING:
     from oqpy.program import Program
@@ -80,7 +80,7 @@ def gate(
     name: str,
     arguments: Optional[list[AstConvertible]] = None,
     declare_here: bool = False,
-) -> Union[Iterator[None], Iterator[list[_ClassicalVar]], Iterator[_ClassicalVar]]:
+) -> Union[Iterator[None], Iterator[list[AngleVar]], Iterator[AngleVar]]:
     """Context manager for creating a gate.
 
     .. code-block:: python

--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -25,8 +25,8 @@ from mypy_extensions import VarArg
 from openpulse import ast
 
 import oqpy.program
-from oqpy.base import AstConvertible, OQPyExpression, make_annotations, map_to_ast, to_ast
-from oqpy.classical_types import OQFunctionCall, _ClassicalVar, AngleVar
+from oqpy.base import AstConvertible, OQPyExpression, make_annotations, to_ast
+from oqpy.classical_types import OQFunctionCall, _ClassicalVar
 from oqpy.quantum_types import Qubit
 from oqpy.timing import convert_float_to_duration
 

--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -30,7 +30,7 @@ from oqpy.classical_types import OQFunctionCall, _ClassicalVar, AngleVar
 from oqpy.quantum_types import Qubit
 from oqpy.timing import convert_float_to_duration
 
-__all__ = ["subroutine", "gate", "declare_extern", "declare_waveform_generator"]
+__all__ = ["subroutine", "declare_extern", "declare_waveform_generator"]
 
 SubroutineParams = [oqpy.Program, VarArg(AstConvertible)]
 
@@ -158,82 +158,6 @@ def subroutine(
         )
 
     setattr(wrapper, "subroutine_declaration", (name, stmt))
-    return wrapper
-
-
-@enable_decorator_arguments
-def gate(
-    func: Callable[[oqpy.Program, VarArg(AstConvertible)], None],
-    annotations: Sequence[str | tuple[str, str]] = (),
-) -> Callable[[oqpy.Program, VarArg(AstConvertible)], ast.QuantumGate]:
-    """Decorator to declare a gate definition.
-    TODO: finish docstring
-    """
-    name = func.__name__
-    identifier = ast.Identifier(func.__name__)
-    argnames = list(inspect.signature(func).parameters.keys())
-    type_hints = get_type_hints(func)
-    inputs = {}  # used as inputs when calling the actual python function
-    qubits = []  # used in the ast definition of the subroutine
-    angles = []  # used in the ast definition of the subroutine
-    for argname in argnames[1:]:  # arg 0 should be program
-        if argname not in type_hints:
-            raise ValueError(f"No type hint provided for {argname} on gate {name}.")
-        input_ = inputs[argname] = type_hints[argname](name=argname)
-        # TODO: enforce the order of the arguments in some way
-        if isinstance(input_, AngleVar):
-            angles.append(ast.Identifier(argname))
-        elif isinstance(input_, Qubit):
-            qubits.append(ast.Identifier(input_.name))
-        else:
-            raise ValueError(f"Type hint for {argname} on gate {name} is not Qubit or AngleVar.")
-
-    inner_prog = oqpy.Program()
-    for input_val in inputs.values():
-        inner_prog._mark_var_declared(input_val)
-    output = func(inner_prog, **inputs)
-    inner_prog.autodeclare()
-    inner_prog._state.finalize_if_clause()
-    body = inner_prog._state.body
-    # TODO: validation on body that everything is allowed in a gate definition
-    if output is not None:
-        raise ValueError(
-            f"Return value of gate definition {name} is not None. "
-            f"Gate definitions are not allowed to return any value."
-        )
-    stmt = ast.QuantumGateDefinition(
-        identifier,
-        arguments=angles,
-        qubits=qubits,
-        body=body,
-    )
-    stmt.annotations = make_annotations(annotations)
-
-    @functools.wraps(func)
-    def wrapper(
-        program: oqpy.Program,
-        *args: AstConvertible,
-    ) -> ast.QuantumGate:
-        for gate_name, gate_stmt in inner_prog.gates.items():
-            program._add_gate(gate_name, gate_stmt)
-        program._add_gate(name, stmt)
-        angles = []
-        qubits = []
-        for arg in args:
-            if isinstance(arg, Qubit):
-                qubits.append(arg)
-            else:
-                angles.append(arg)
-        gate_call = ast.QuantumGate(
-            [],
-            ast.Identifier(name),
-            map_to_ast(program, angles),
-            map_to_ast(program, qubits),
-        )
-        program._add_statement(gate_call)
-        return gate_call
-
-    setattr(wrapper, "gate_declaration", (name, stmt))
     return wrapper
 
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2198,17 +2198,15 @@ def test_nested_subroutines():
 
 
 def test_nested_gates():
-    @oqpy.gate
-    def rz(prog: oqpy.Program, q: oqpy.Qubit, theta: oqpy.AngleVar) -> None:
-        prog.gate(q, "U", theta, 0, 0)
-
-    @oqpy.gate
-    def t(prog: oqpy.Program, q: oqpy.Qubit) -> None:
-        rz(prog, q, 0.3927)
-
     prog = oqpy.Program()
-    t(prog, oqpy.PhysicalQubits[1])
-    t(prog, oqpy.PhysicalQubits[2])
+    q = oqpy.Qubit("q", needs_declaration=False)
+    with oqpy.quantum_types.gate(prog, q, "rz", [oqpy.AngleVar(name="theta")]) as theta:
+        prog.gate(q, "U", theta, 0, 0)
+    with oqpy.quantum_types.gate(prog, q, "t"):
+        prog.gate(q, "rz", oqpy.pi/8)
+
+    prog.gate(oqpy.PhysicalQubits[1], "t")
+    prog.gate(oqpy.PhysicalQubits[2], "t")
 
     expected = textwrap.dedent(
         """
@@ -2217,7 +2215,7 @@ def test_nested_gates():
             U(theta, 0, 0) q;
         }
         gate t q {
-            rz(0.3927) q;
+            rz(pi / 8) q;
         }
         t $1;
         t $2;

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2223,7 +2223,7 @@ def test_nested_gates():
     with oqpy.gate(prog, q, "rz", [oqpy.AngleVar(name="theta")]) as theta:
         prog.gate(q, "u", theta, 0, 0)
     with oqpy.gate(prog, q, "t"):
-        prog.gate(q, "rz", oqpy.pi/8)
+        prog.gate(q, "rz", oqpy.pi / 4)
 
     prog.gate(oqpy.PhysicalQubits[1], "t")
     prog.gate(oqpy.PhysicalQubits[2], "t")
@@ -2241,7 +2241,7 @@ def test_nested_gates():
             u(theta, 0, 0) q;
         }
         gate t q {
-            rz(pi / 8) q;
+            rz(pi / 4) q;
         }
         t $1;
         t $2;

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2200,9 +2200,9 @@ def test_nested_subroutines():
 def test_nested_gates():
     prog = oqpy.Program()
     q = oqpy.Qubit("q", needs_declaration=False)
-    with oqpy.quantum_types.gate(prog, q, "rz", [oqpy.AngleVar(name="theta")]) as theta:
+    with oqpy.gate(prog, q, "rz", [oqpy.AngleVar(name="theta")]) as theta:
         prog.gate(q, "U", theta, 0, 0)
-    with oqpy.quantum_types.gate(prog, q, "t"):
+    with oqpy.gate(prog, q, "t"):
         prog.gate(q, "rz", oqpy.pi/8)
 
     prog.gate(oqpy.PhysicalQubits[1], "t")

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2212,7 +2212,7 @@ def test_invalid_gates():
             pass
 
 
-def test_nested_gates():
+def test_gate_declarations():
     prog = oqpy.Program()
     q = oqpy.Qubit("q", needs_declaration=False)
     with oqpy.gate(prog, q, "u", [oqpy.AngleVar(name="alpha"), oqpy.AngleVar(name="beta"), oqpy.AngleVar(name="gamma")]) as (alpha, beta, gamma):
@@ -2220,7 +2220,7 @@ def test_nested_gates():
         prog.gate(q, "b", beta)
         prog.gate(q, "c", gamma)
         prog.gate(q, "d")
-    with oqpy.gate(prog, q, "rz", [oqpy.AngleVar(name="theta")]) as theta:
+    with oqpy.gate(prog, q, "rz", [oqpy.AngleVar(name="theta")], declare_here=True) as theta:
         prog.gate(q, "u", theta, 0, 0)
     with oqpy.gate(prog, q, "t"):
         prog.gate(q, "rz", oqpy.pi / 4)
@@ -2237,11 +2237,11 @@ def test_nested_gates():
             c(gamma) q;
             d q;
         }
-        gate rz(theta) q {
-            u(theta, 0, 0) q;
-        }
         gate t q {
             rz(pi / 4) q;
+        }
+        gate rz(theta) q {
+            u(theta, 0, 0) q;
         }
         t $1;
         t $2;

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2195,3 +2195,33 @@ def test_nested_subroutines():
     ).strip()
 
     assert prog.to_qasm() == expected
+
+
+def test_nested_gates():
+    @oqpy.gate
+    def rz(prog: oqpy.Program, q: oqpy.Qubit, theta: oqpy.AngleVar) -> None:
+        prog.gate(q, "U", theta, 0, 0)
+
+    @oqpy.gate
+    def t(prog: oqpy.Program, q: oqpy.Qubit) -> None:
+        rz(prog, q, 0.3927)
+        
+    prog = oqpy.Program()
+    t(prog, oqpy.PhysicalQubits[1])
+    t(prog, oqpy.PhysicalQubits[2])
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        gate rz(theta) q {
+            U(theta, 0, 0) q;
+        }
+        gate t q {
+            rz(0.3927) q;
+        }
+        t $1;
+        t $2;
+        """
+    ).strip()
+
+    assert prog.to_qasm() == expected

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2205,7 +2205,7 @@ def test_nested_gates():
     @oqpy.gate
     def t(prog: oqpy.Program, q: oqpy.Qubit) -> None:
         rz(prog, q, 0.3927)
-        
+
     prog = oqpy.Program()
     t(prog, oqpy.PhysicalQubits[1])
     t(prog, oqpy.PhysicalQubits[2])


### PR DESCRIPTION
This PR implements support for `gate` definitions (issue #1).

The spec for `gate` definitions is contained here: https://openqasm.com/language/gates.html

Basic usage is as follows:
```
prog = oqpy.Program()
q = oqpy.Qubit("q", needs_declaration=False)
with oqpy.gate(prog, q, "rz", [oqpy.AngleVar(name="theta")]) as theta:
    prog.gate(q, "u", theta, 0, 0)
with oqpy.gate(prog, q, "t"):
    prog.gate(q, "rz", oqpy.pi / 4)
prog.gate(oqpy.PhysicalQubits[0], "t")
print(prog.to_qasm())
```
produces:
```
OPENQASM 3.0;
gate rz(theta) q {
    u(theta, 0, 0) q;
}
gate t q {
    rz(pi / 4) q;
}
t $0;
```
