### PR TITLE
Support BitVar indexing

### DIFF
--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -287,6 +287,8 @@ class BitVar(_SizedVar):
                 )
             else:
                 raise IndexError("list index out of range.")
+        elif isinstance(idx, OQPyExpression) and isinstance(idx.type, (ast.IntType, ast.UintType)):
+            return OQIndexExpression(collection=self, index=idx)
         else:
             raise IndexError("The list index must be an integer.")
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -126,6 +126,9 @@ def test_variable_declaration():
     prog = Program(version=None)
     prog.declare(vars)
     prog.set(arr[1], 0)
+    index = IntVar(2, "index")
+    prog.set(arr[index], 1)
+    prog.set(arr[index + 1], 0)
 
     with pytest.raises(IndexError):
         prog.set(arr[40], 2)
@@ -142,6 +145,7 @@ def test_variable_declaration():
 
     expected = textwrap.dedent(
         """
+        int[32] index = 2;
         bool b = true;
         int[32] i = -4;
         uint[32] u = 5;
@@ -151,6 +155,8 @@ def test_variable_declaration():
         bit[20] arr;
         bit c;
         arr[1] = 0;
+        arr[index] = 1;
+        arr[index + 1] = 0;
         """
     ).strip()
 


### PR DESCRIPTION
Related issue: https://github.com/openqasm/oqpy/issues/62

This PR ads support for BitVar indexing with an integer variable.
```
prog = Program(version=None)
arr = BitVar[20](name="arr")
index = IntVar(2, "index")
prog.set(arr[index], 1)
prog.set(arr[index+1], 0)
```
produces OpenQASM script
```
bit[20] arr;
int[32] index = 2;
arr[index] = 1;
arr[index + 1] = 0;
```
