### PR TITLE
Simplified implementation of gate modifiers

### DIFF
--- a/oqpy/__init__.py
+++ b/oqpy/__init__.py
@@ -19,6 +19,6 @@ from oqpy.classical_types import *
 from oqpy.control_flow import *
 from oqpy.program import *
 from oqpy.pulse import *
-from oqpy.quantum_types import *  # pylint: disable=redefined-builtin
+from oqpy.quantum_types import *
 from oqpy.subroutines import *
 from oqpy.timing import *

--- a/oqpy/__init__.py
+++ b/oqpy/__init__.py
@@ -19,6 +19,6 @@ from oqpy.classical_types import *
 from oqpy.control_flow import *
 from oqpy.program import *
 from oqpy.pulse import *
-from oqpy.quantum_types import *
+from oqpy.quantum_types import *  # pylint: disable=redefined-builtin
 from oqpy.subroutines import *
 from oqpy.timing import *

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -516,7 +516,11 @@ class Program:
                     argument=to_ast(self, len(neg_controls)) if len(neg_controls) > 1 else None,
                 )
             )
-            used_qubits.extend(sorted(neg_controls))
+            for qubit in sorted(neg_controls):
+                if qubit in used_qubits:
+                    raise ValueError(f"Qubit {qubit} has already been defined as a control qubit.")
+                else:
+                    used_qubits.append(qubit)
 
         if inv:
             modifiers.append(
@@ -535,7 +539,13 @@ class Program:
         if isinstance(qubits, quantum_types.Qubit):
             qubits = [qubits]
         assert isinstance(qubits, Iterable)
-        used_qubits.extend(qubits)
+        for qubit in qubits:
+            if qubit in used_qubits:
+                raise ValueError(
+                    f"Qubit {qubit} has already been defined as a control qubit or a negative control qubit."
+                )
+            else:
+                used_qubits.append(qubit)
 
         self._add_statement(
             ast.QuantumGate(

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -483,19 +483,21 @@ class Program:
         self,
         qubits: AstConvertible | Iterable[AstConvertible],
         name: str,
-        controls: AstConvertible | Iterable[AstConvertible] | None,
-        neg_controls: AstConvertible | Iterable[AstConvertible] | None,
-        inv: bool = False,
-        pow: AstConvertible = 1,
         *args: Any,
+        controls: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None = None,
+        neg_controls: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None = None,
+        inv: bool = False,
+        pow: AstConvertible = 1,  # pylint: disable=redefined-builtin
     ) -> Program:
         """Apply a gate to a qubit or set of qubits."""
-        used_qubits = []
+        used_qubits: list[AstConvertible] = []
 
         modifiers = []
-        if neg_controls is not None:
-            if isinstance(neg_controls, quantum_types.Qubit):
-                controls = [controls]
+        neg_controls = neg_controls if neg_controls is not None else []
+        neg_controls = (
+            [neg_controls] if isinstance(neg_controls, quantum_types.Qubit) else list(neg_controls)
+        )
+        if neg_controls:
             modifiers.append(
                 ast.QuantumGateModifier(
                     modifier=ast.GateModifierName.negctrl,
@@ -503,10 +505,10 @@ class Program:
                 )
             )
             used_qubits.extend(neg_controls)
-        assert isinstance(neg_controls, Iterable)
-        if controls is not None:
-            if isinstance(controls, quantum_types.Qubit):
-                controls = [controls]
+
+        controls = controls if controls is not None else []
+        controls = [controls] if isinstance(controls, quantum_types.Qubit) else list(controls)
+        if controls:
             modifiers.append(
                 ast.QuantumGateModifier(
                     modifier=ast.GateModifierName.ctrl,
@@ -514,7 +516,6 @@ class Program:
                 )
             )
             used_qubits.extend(controls)
-        assert isinstance(controls, Iterable)
 
         if inv:
             modifiers.append(

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -480,6 +480,60 @@ class Program:
         self._add_statement(ast.ReturnStatement(to_ast(self, expression)))
         return self
 
+    def _create_modifiers_ast(
+        self,
+        control: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None,
+        neg_control: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None,
+        inv: bool,
+        exp: AstConvertible,
+    ) -> tuple[list[ast.QuantumGateModifier], list[AstConvertible]]:
+        """Create the AST for the gate modifiers."""
+        used_qubits: list[AstConvertible] = []
+        modifiers: list[ast.QuantumGateModifier] = []
+
+        control = control if control is not None else []
+        control = {control} if isinstance(control, quantum_types.Qubit) else set(control)
+        if control:
+            modifiers.append(
+                ast.QuantumGateModifier(
+                    modifier=ast.GateModifierName.ctrl,
+                    argument=to_ast(self, len(control)) if len(control) > 1 else None,
+                )
+            )
+            used_qubits.extend(sorted(control))
+
+        neg_control = neg_control if neg_control is not None else []
+        neg_control = (
+            {neg_control} if isinstance(neg_control, quantum_types.Qubit) else set(neg_control)
+        )
+        if neg_control:
+            modifiers.append(
+                ast.QuantumGateModifier(
+                    modifier=ast.GateModifierName.negctrl,
+                    argument=to_ast(self, len(neg_control)) if len(neg_control) > 1 else None,
+                )
+            )
+            for qubit in sorted(neg_control):
+                if qubit in used_qubits:
+                    raise ValueError(f"Qubit {qubit} has already been defined as a control qubit.")
+                else:
+                    used_qubits.append(qubit)
+
+        if inv:
+            modifiers.append(
+                ast.QuantumGateModifier(
+                    modifier=ast.GateModifierName.inv,
+                )
+            )
+
+        if isinstance(exp, OQPyExpression) or (isinstance(exp, float) and exp != 1.0):
+            modifiers.append(
+                ast.QuantumGateModifier(
+                    modifier=ast.GateModifierName.pow, argument=to_ast(self, exp)
+                )
+            )
+        return modifiers, used_qubits
+
     def gate(
         self,
         qubits: AstConvertible | Iterable[AstConvertible],
@@ -507,63 +561,7 @@ class Program:
         Returns:
             Program: The OQpy program to which the gate is added
         """
-
-        def _create_modifiers_ast(
-            control: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None,
-            neg_control: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None,
-            inv: bool,
-            exp: AstConvertible,
-        ) -> tuple[list[ast.QuantumGateModifier], list[AstConvertible]]:
-            """Create the AST for the gate modifiers."""
-            used_qubits: list[AstConvertible] = []
-            modifiers: list[ast.QuantumGateModifier] = []
-
-            control = control if control is not None else []
-            control = {control} if isinstance(control, quantum_types.Qubit) else set(control)
-            if control:
-                modifiers.append(
-                    ast.QuantumGateModifier(
-                        modifier=ast.GateModifierName.ctrl,
-                        argument=to_ast(self, len(control)) if len(control) > 1 else None,
-                    )
-                )
-                used_qubits.extend(sorted(control))
-
-            neg_control = neg_control if neg_control is not None else []
-            neg_control = (
-                {neg_control} if isinstance(neg_control, quantum_types.Qubit) else set(neg_control)
-            )
-            if neg_control:
-                modifiers.append(
-                    ast.QuantumGateModifier(
-                        modifier=ast.GateModifierName.negctrl,
-                        argument=to_ast(self, len(neg_control)) if len(neg_control) > 1 else None,
-                    )
-                )
-                for qubit in sorted(neg_control):
-                    if qubit in used_qubits:
-                        raise ValueError(
-                            f"Qubit {qubit} has already been defined as a control qubit."
-                        )
-                    else:
-                        used_qubits.append(qubit)
-
-            if inv:
-                modifiers.append(
-                    ast.QuantumGateModifier(
-                        modifier=ast.GateModifierName.inv,
-                    )
-                )
-
-            if isinstance(exp, OQPyExpression) or (isinstance(exp, float) and exp != 1.0):
-                modifiers.append(
-                    ast.QuantumGateModifier(
-                        modifier=ast.GateModifierName.pow, argument=to_ast(self, exp)
-                    )
-                )
-            return modifiers, used_qubits
-
-        modifiers, used_qubits = _create_modifiers_ast(control, neg_control, inv, exp)
+        modifiers, used_qubits = self._create_modifiers_ast(control, neg_control, inv, exp)
 
         if isinstance(qubits, (quantum_types.Qubit, quantum_types.IndexedQubitArray)):
             qubits = [qubits]

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -480,7 +480,10 @@ class Program:
         return self
 
     def gate(
-        self, qubits: AstConvertible | Iterable[AstConvertible], name: str, *args: Any
+        self,
+        qubits: AstConvertible | Iterable[AstConvertible],
+        name: str,
+        *args: Any,
     ) -> Program:
         """Apply a gate to a qubit or set of qubits."""
         if isinstance(qubits, quantum_types.Qubit):

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -485,8 +485,8 @@ class Program:
         qubits: AstConvertible | Iterable[AstConvertible],
         name: str,
         *args: Any,
-        controls: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None = None,
-        neg_controls: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None = None,
+        control: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None = None,
+        neg_control: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None = None,
         inv: bool = False,
         exp: AstConvertible = 1,
     ) -> Program:
@@ -497,9 +497,9 @@ class Program:
                 to which the gate will be applied
             name (str): The gate name
             *args (Any): A list of parameters passed to the gate
-            controls (quantum_types.Qubit | Iterable[quantum_types.Qubit] | None): The list
+            control (quantum_types.Qubit | Iterable[quantum_types.Qubit] | None): The list
                 of control qubits (default: None)
-            neg_controls: (quantum_types.Qubit | Iterable[quantum_types.Qubit] | None): The list
+            neg_control: (quantum_types.Qubit | Iterable[quantum_types.Qubit] | None): The list
                 of negative control qubits (default: None)
             inv (bool): Flag to use the inverse gate (default: False)
             exp (AstConvertible): The exponent used with `pow` gate modifier
@@ -510,29 +510,29 @@ class Program:
         used_qubits: list[AstConvertible] = []
         modifiers = []
 
-        controls = controls if controls is not None else []
-        controls = {controls} if isinstance(controls, quantum_types.Qubit) else set(controls)
-        if controls:
+        control = control if control is not None else []
+        control = {control} if isinstance(control, quantum_types.Qubit) else set(control)
+        if control:
             modifiers.append(
                 ast.QuantumGateModifier(
                     modifier=ast.GateModifierName.ctrl,
-                    argument=to_ast(self, len(controls)) if len(controls) > 1 else None,
+                    argument=to_ast(self, len(control)) if len(control) > 1 else None,
                 )
             )
-            used_qubits.extend(sorted(controls))
+            used_qubits.extend(sorted(control))
 
-        neg_controls = neg_controls if neg_controls is not None else []
-        neg_controls = (
-            {neg_controls} if isinstance(neg_controls, quantum_types.Qubit) else set(neg_controls)
+        neg_control = neg_control if neg_control is not None else []
+        neg_control = (
+            {neg_control} if isinstance(neg_control, quantum_types.Qubit) else set(neg_control)
         )
-        if neg_controls:
+        if neg_control:
             modifiers.append(
                 ast.QuantumGateModifier(
                     modifier=ast.GateModifierName.negctrl,
-                    argument=to_ast(self, len(neg_controls)) if len(neg_controls) > 1 else None,
+                    argument=to_ast(self, len(neg_control)) if len(neg_control) > 1 else None,
                 )
             )
-            for qubit in sorted(neg_controls):
+            for qubit in sorted(neg_control):
                 if qubit in used_qubits:
                     raise ValueError(f"Qubit {qubit} has already been defined as a control qubit.")
                 else:

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -488,9 +488,25 @@ class Program:
         controls: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None = None,
         neg_controls: quantum_types.Qubit | Iterable[quantum_types.Qubit] | None = None,
         inv: bool = False,
-        pow: AstConvertible = 1,  # pylint: disable=redefined-builtin
+        exp: AstConvertible = 1,
     ) -> Program:
-        """Apply a gate to a qubit or set of qubits."""
+        """Apply a gate with its modifiers to a qubit or set of qubits.
+
+        Args:
+            qubits (AstConvertible | Iterable[AstConvertible]): The qubit or list of qubits
+                to which the gate will be applied
+            name (str): The gate name
+            *args (Any): A list of parameters passed to the gate
+            controls (quantum_types.Qubit | Iterable[quantum_types.Qubit] | None): The list
+                of control qubits (default: None)
+            neg_controls: (quantum_types.Qubit | Iterable[quantum_types.Qubit] | None): The list
+                of negative control qubits (default: None)
+            inv (bool): Flag to use the inverse gate (default: False)
+            exp (AstConvertible): The exponent used with `pow` gate modifier
+
+        Returns:
+            Program: The OQpy program to which the gate is added
+        """
         used_qubits: list[AstConvertible] = []
         modifiers = []
 
@@ -529,10 +545,10 @@ class Program:
                 )
             )
 
-        if isinstance(pow, OQPyExpression) or (isinstance(pow, float) and pow != 1.0):
+        if isinstance(exp, OQPyExpression) or (isinstance(exp, float) and exp != 1.0):
             modifiers.append(
                 ast.QuantumGateModifier(
-                    modifier=ast.GateModifierName.pow, argument=to_ast(self, pow)
+                    modifier=ast.GateModifierName.pow, argument=to_ast(self, exp)
                 )
             )
 

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -146,17 +146,31 @@ class pow(OQpyGateModifier):  # pylint: disable=redefined-builtin
 class ctrl(OQpyGateModifier):
     """ctrl gate modifier."""
 
+    def __init__(self, control_number: AstConvertible | None = None) -> None:
+        self.control_number = control_number
+        super().__init__()
+
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the OQpy object into an ast node."""
-        return ast.QuantumGateModifier(ast.GateModifierName.ctrl)
+        return ast.QuantumGateModifier(
+            ast.GateModifierName.ctrl,
+            to_ast(program, self.control_number) if self.control_number else None,
+        )
 
 
 class negctrl(OQpyGateModifier):
-    """ctrl gate modifier."""
+    """negctrl gate modifier."""
+
+    def __init__(self, control_number: AstConvertible | None = None) -> None:
+        self.control_number = control_number
+        super().__init__()
 
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the OQpy object into an ast node."""
-        return ast.QuantumGateModifier(ast.GateModifierName.negctrl)
+        return ast.QuantumGateModifier(
+            ast.GateModifierName.negctrl,
+            to_ast(program, self.control_number) if self.control_number else None,
+        )
 
 
 @contextlib.contextmanager

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -24,13 +24,13 @@ from openpulse import ast
 from openpulse.printer import dumps
 
 from oqpy.base import AstConvertible, Var, make_annotations, to_ast
-from oqpy.classical_types import _ClassicalVar
+from oqpy.classical_types import AngleVar, _ClassicalVar
 
 if TYPE_CHECKING:
     from oqpy.program import Program
 
 
-__all__ = ["Qubit", "QubitArray", "defcal", "PhysicalQubits", "Cal"]
+__all__ = ["Qubit", "QubitArray", "defcal", "gate", "PhysicalQubits", "Cal"]
 
 
 class Qubit(Var):
@@ -71,6 +71,56 @@ class PhysicalQubits:
 # Todo (#51): support QubitArray
 class QubitArray:
     """Represents an array of qubits."""
+
+
+@contextlib.contextmanager
+def gate(
+    program: Program,
+    qubits: Union[Qubit, list[Qubit]],
+    name: str,
+    arguments: Optional[list[AstConvertible]] = None,
+    declare_here: bool = False,
+) -> Union[Iterator[None], Iterator[list[AngleVar]], Iterator[AngleVar]]:
+    """Context manager for creating a gate.
+
+    .. code-block:: python
+
+        with gate(program, q1, "HRzH", [AngleVar(name="theta")]) as theta:
+            program.gate(q1, "H")
+            program.gate(q1, "Rz", theta)
+            program.gate(q1, "H")
+    """
+    if isinstance(qubits, Qubit):
+        qubits = [qubits]
+
+    arguments_ast = []
+    variables = []
+    if arguments is not None:
+        for arg in arguments:
+            if not isinstance(arg, AngleVar):
+                raise ValueError(arg, "Gates only support args of type AngleVar.")
+            arguments_ast.append(ast.Identifier(name=arg.name))
+            arg._needs_declaration = False
+            variables.append(arg)
+
+    program._push()
+    if len(variables) > 1:
+        yield variables
+    elif len(variables) == 1:
+        yield variables[0]
+    else:
+        yield None
+    state = program._pop()
+
+    stmt = ast.QuantumGateDefinition(
+        name=ast.Identifier(name),
+        arguments=arguments_ast,
+        qubits=[ast.Identifier(q.name) for q in qubits],
+        body=state.body,
+    )
+    if declare_here:
+        program._add_statement(stmt)
+    program._add_gate(name, stmt, needs_declaration=not declare_here)
 
 
 @contextlib.contextmanager

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -115,6 +115,12 @@ class OQPyGateModifier(HasToAst):
             self.neg_control_qubits if hasattr(self, "neg_control_qubits") else set()
         )
         for modifier in self.modifiers:
+            if overlapping_set := self.control_qubits.intersection(
+                modifier.neg_control_qubits
+            ).union(self.neg_control_qubits.intersection(modifier.control_qubits)):
+                raise ValueError(
+                    f"Qubits {[q.name for q in overlapping_set]} can be control and negative control qubit at the same time."
+                )
             self.control_qubits.update(modifier.control_qubits)
             self.neg_control_qubits.update(modifier.neg_control_qubits)
 

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -18,13 +18,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import (
-    TYPE_CHECKING,
-    Iterator,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Iterator, Optional, Sequence, Union
 
 from openpulse import ast
 from openpulse.printer import dumps

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -44,10 +44,11 @@ __all__ = [
     "gate",
     "PhysicalQubits",
     "Cal",
-    "ctrl",
+    "OQpyGateModifier",
     "inv",
     "pow",
-    "OQpyGateModifier",
+    "ctrl",
+    "negctrl",
 ]
 
 
@@ -122,14 +123,6 @@ class OQpyGateModifier(HasToAst):
         return map_to_ast(program, self.modifiers)
 
 
-class ctrl(OQpyGateModifier):
-    """ctrl gate modifier."""
-
-    def to_ast(self, program: Program) -> ast.Expression:
-        """Converts the OQpy object into an ast node."""
-        return ast.QuantumGateModifier(ast.GateModifierName.ctrl)
-
-
 class inv(OQpyGateModifier):
     """inv gate modifier."""
 
@@ -148,6 +141,22 @@ class pow(OQpyGateModifier):  # pylint: disable=redefined-builtin
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the OQpy object into an ast node."""
         return ast.QuantumGateModifier(ast.GateModifierName.pow, to_ast(program, self.expression))
+
+
+class ctrl(OQpyGateModifier):
+    """ctrl gate modifier."""
+
+    def to_ast(self, program: Program) -> ast.Expression:
+        """Converts the OQpy object into an ast node."""
+        return ast.QuantumGateModifier(ast.GateModifierName.ctrl)
+
+
+class negctrl(OQpyGateModifier):
+    """ctrl gate modifier."""
+
+    def to_ast(self, program: Program) -> ast.Expression:
+        """Converts the OQpy object into an ast node."""
+        return ast.QuantumGateModifier(ast.GateModifierName.negctrl)
 
 
 @contextlib.contextmanager

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -105,7 +105,12 @@ class OQpyGateModifier(HasToAst):
             and len(rhs._state.body) >= 0
             and isinstance(rhs._state.body[-1], ast.QuantumGate)
         ):
-            rhs._state.body[-1].modifiers = map_to_ast(rhs, self.modifiers)
+            modifiers_ast = self.to_ast(rhs)
+            rhs._state.body[-1].modifiers = (
+                [modifiers_ast]
+                if isinstance(modifiers_ast, ast.QuantumGateModifier)
+                else modifiers_ast
+            )
             return rhs
         else:
             raise RuntimeError(
@@ -114,7 +119,7 @@ class OQpyGateModifier(HasToAst):
 
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the OQpy object into an ast node."""
-        raise NotImplementedError
+        return map_to_ast(program, self.modifiers)
 
 
 class ctrl(OQpyGateModifier):

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Iterator, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Sequence, Union
 
 from openpulse import ast
 from openpulse.printer import dumps
@@ -27,6 +27,7 @@ import oqpy
 from oqpy.base import (
     AstConvertible,
     HasToAst,
+    OQPyExpression,
     Var,
     make_annotations,
     map_to_ast,
@@ -44,7 +45,7 @@ __all__ = [
     "gate",
     "PhysicalQubits",
     "Cal",
-    "OQpyGateModifier",
+    "OQPyGateModifier",
     "inv",
     "pow",
     "ctrl",
@@ -64,6 +65,15 @@ class Qubit(Var):
         super().__init__(name, needs_declaration=needs_declaration)
         self.name = name
         self.annotations = annotations
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Qubit) and self.name == other.name
+
+    def __lt__(self, other: Qubit) -> bool:
+        return self.name < other.name
 
     def to_ast(self, prog: Program) -> ast.Expression:
         """Converts the OQpy variable into an ast node."""
@@ -93,25 +103,43 @@ class QubitArray:
     """Represents an array of qubits."""
 
 
-class OQpyGateModifier(HasToAst):
+class OQPyGateModifier(HasToAst):
     """A generic gate modifier."""
 
-    def __init__(self, modifiers: list[OQpyGateModifier] | None = None) -> None:
+    def __init__(self, modifiers: list[OQPyGateModifier] | None = None) -> None:
         self.modifiers = modifiers if modifiers else [self]
+        self.control_qubits: set[Qubit] = (
+            self.control_qubits if hasattr(self, "control_qubits") else set()
+        )
+        self.neg_control_qubits: set[Qubit] = (
+            self.neg_control_qubits if hasattr(self, "neg_control_qubits") else set()
+        )
+        for modifier in self.modifiers:
+            self.control_qubits.update(modifier.control_qubits)
+            self.neg_control_qubits.update(modifier.neg_control_qubits)
 
-    def __matmul__(self, rhs: Program | OQpyGateModifier) -> Program | OQpyGateModifier:
-        if isinstance(rhs, OQpyGateModifier):
-            return OQpyGateModifier(self.modifiers + [rhs])
+    def __repr__(self) -> str:
+        return " @ ".join([str(modifier) for modifier in self.modifiers])
+
+    def __matmul__(self, rhs: Program | OQPyGateModifier) -> Program | OQPyGateModifier:
+        if isinstance(rhs, OQPyGateModifier):
+            return OQPyGateModifier(self.modifiers + [rhs])
         elif (
             isinstance(rhs, oqpy.Program)
             and len(rhs._state.body) >= 0
             and isinstance(rhs._state.body[-1], ast.QuantumGate)
         ):
             modifiers_ast = self.to_ast(rhs)
-            rhs._state.body[-1].modifiers = (
+            modifiers_ast = (
                 [modifiers_ast]
                 if isinstance(modifiers_ast, ast.QuantumGateModifier)
                 else modifiers_ast
+            )
+            rhs._state.body[-1].modifiers = modifiers_ast + rhs._state.body[-1].modifiers
+            rhs._state.body[-1].qubits = (
+                map_to_ast(rhs, sorted(self.control_qubits))
+                + map_to_ast(rhs, sorted(self.neg_control_qubits))
+                + rhs._state.body[-1].qubits
             )
             return rhs
         else:
@@ -121,56 +149,92 @@ class OQpyGateModifier(HasToAst):
 
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the OQpy object into an ast node."""
-        return map_to_ast(program, self.modifiers)
+        simplified_modifiers: list[OQPyGateModifier] = []
+        odd_number_inv = False
+        power: AstConvertible = 1.0
+        for mod in self.modifiers:
+            if isinstance(mod, inv):
+                odd_number_inv ^= True
+            elif isinstance(mod, pow):
+                power = (
+                    power * mod.expression  # type: ignore[operator]
+                    if not isinstance(power, float) or power != 1.0
+                    else mod.expression
+                )
+
+        if len(self.control_qubits):
+            simplified_modifiers.append(ctrl(self.control_qubits))
+        if len(self.neg_control_qubits):
+            simplified_modifiers.append(negctrl(self.neg_control_qubits))
+        if odd_number_inv:
+            simplified_modifiers.append(inv())
+        # FIXME: Should we test OQPyExpression or AstConvertible
+        if isinstance(power, OQPyExpression) or (isinstance(power, float) and power != 1.0):
+            simplified_modifiers.append(pow(power))
+        return map_to_ast(program, simplified_modifiers)
 
 
-class inv(OQpyGateModifier):
+class inv(OQPyGateModifier):
     """inv gate modifier."""
+
+    def __repr__(self) -> str:
+        return "inv"
 
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the OQpy object into an ast node."""
         return ast.QuantumGateModifier(ast.GateModifierName.inv)
 
 
-class pow(OQpyGateModifier):  # pylint: disable=redefined-builtin
+class pow(OQPyGateModifier):  # pylint: disable=redefined-builtin
     """pow gate modifier."""
 
     def __init__(self, expression: AstConvertible) -> None:
         self.expression = expression
         super().__init__()
 
+    def __repr__(self) -> str:
+        return f"pow({self.expression})"
+
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the OQpy object into an ast node."""
         return ast.QuantumGateModifier(ast.GateModifierName.pow, to_ast(program, self.expression))
 
 
-class ctrl(OQpyGateModifier):
+class ctrl(OQPyGateModifier):
     """ctrl gate modifier."""
 
-    def __init__(self, control_number: AstConvertible | None = None) -> None:
-        self.control_number = control_number
+    def __init__(self, qubits: Qubit | Iterable[Qubit]) -> None:
+        self.control_qubits = {qubits} if isinstance(qubits, Qubit) else set(qubits)
         super().__init__()
+
+    def __repr__(self) -> str:
+        return f"ctrl({', '.join([q.name for q in self.control_qubits])})"
 
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the OQpy object into an ast node."""
         return ast.QuantumGateModifier(
             ast.GateModifierName.ctrl,
-            to_ast(program, self.control_number) if self.control_number else None,
+            to_ast(program, len(self.control_qubits)) if len(self.control_qubits) > 1 else None,
         )
 
 
-class negctrl(OQpyGateModifier):
+class negctrl(OQPyGateModifier):
     """negctrl gate modifier."""
 
-    def __init__(self, control_number: AstConvertible | None = None) -> None:
-        self.control_number = control_number
+    def __init__(self, qubits: Qubit | Iterable[Qubit]) -> None:
+        self.neg_control_qubits = {qubits} if isinstance(qubits, Qubit) else set(qubits)
         super().__init__()
+
+    def __repr__(self) -> str:
+        return f"negctrl({', '.join([q.name for q in self.neg_control_qubits])})"
 
     def to_ast(self, program: Program) -> ast.Expression:
         """Converts the OQpy object into an ast node."""
         return ast.QuantumGateModifier(
             ast.GateModifierName.negctrl,
-            to_ast(program, self.control_number) if self.control_number else None,
+            to_ast(program, len(self.neg_control_qubits))
+            if len(self.neg_control_qubits) > 1
+            else None,
         )
 
 

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -84,6 +84,7 @@ class PhysicalQubits:
     """
 
     def __class_getitem__(cls, item: int) -> Qubit:
+        assert isinstance(item, int)
         return Qubit(f"${item}", needs_declaration=False)
 
 

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -20,12 +20,9 @@ from __future__ import annotations
 import contextlib
 from typing import (
     TYPE_CHECKING,
-    Any,
-    Callable,
     Iterator,
     Optional,
     Sequence,
-    TypeVar,
     Union,
 )
 
@@ -58,8 +55,6 @@ __all__ = [
     "pow",
     "OQpyGateModifier",
 ]
-
-FnType = TypeVar("FnType", bound=Callable[..., Any])
 
 
 class Qubit(Var):

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -115,11 +115,17 @@ class OQPyGateModifier(HasToAst):
             self.neg_control_qubits if hasattr(self, "neg_control_qubits") else set()
         )
         for modifier in self.modifiers:
-            if overlapping_set := self.control_qubits.intersection(
+            neg_ctrl_intersection_set = self.control_qubits.intersection(
                 modifier.neg_control_qubits
-            ).union(self.neg_control_qubits.intersection(modifier.control_qubits)):
+            )
+            ctrl_neg_intersection_set = self.neg_control_qubits.intersection(
+                modifier.control_qubits
+            )
+            overlapping_set = neg_ctrl_intersection_set.union(ctrl_neg_intersection_set)
+            if overlapping_set:
                 raise ValueError(
-                    f"Qubits {[q.name for q in overlapping_set]} can be control and negative control qubit at the same time."
+                    f"Qubits {[q.name for q in overlapping_set]} can be control and negative"
+                    " control qubit at the same time."
                 )
             self.control_qubits.update(modifier.control_qubits)
             self.neg_control_qubits.update(modifier.neg_control_qubits)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2200,7 +2200,7 @@ def test_nested_subroutines():
     _check_respects_type_hints(prog)
 
 
-def test_gate_modifiers_second_method():
+def test_gate_modifiers():
     prog = oqpy.Program()
     qreg = [oqpy.PhysicalQubits[i] for i in range(0, 8)]
     six_qubit_reg = [qreg[i] for i in [1, 4, 7, 2, 3, 5]]
@@ -2208,13 +2208,8 @@ def test_gate_modifiers_second_method():
     prog.gate(qreg[2], "t", controls=qreg[1])
     prog.gate(qreg[2], "x", neg_controls=qreg[1])
     prog.gate(qreg[3], "rz", inv=True)
-    prog.gate(qreg[4], "rz", inv=False)
-    prog.gate(qreg[5], "rz", inv=True)
     prog.gate(qreg[2], "t", pow=0.5)
-
-    prog.gate(qreg[2], "t", pow=0.6 * 1 / 2)
-
-    prog.gate(qreg[0], "x", inv=True, pow=oqpy.IntVar(5, "i") / 2 * 2)
+    prog.gate(qreg[0], "x", inv=True, pow=oqpy.IntVar(5, "i") / 2)
 
     prog.gate(
         six_qubit_reg[-1],
@@ -2246,11 +2241,8 @@ def test_gate_modifiers_second_method():
         ctrl @ t $1, $2;
         negctrl @ x $1, $2;
         inv @ rz $3;
-        rz $4;
-        inv @ rz $5;
         pow(0.5) @ t $2;
-        pow(0.3) @ t $2;
-        inv @ pow(i / 2 * 2) @ x $0;
+        inv @ pow(i / 2) @ x $0;
         ctrl(2) @ negctrl(3) @ inv @ pow(0.5) @ x $1, $4, $2, $3, $7, $5;
         ctrl(3) @ negctrl(2) @ rz1 $2, $4, $5, $0, $1, $6;
         """

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2263,6 +2263,7 @@ def test_gate_modifiers():
     reg = [oqpy.PhysicalQubits[i] for i in range(1, 3)]
 
     oqpy.ctrl() @ prog.gate(reg, "t")
+    oqpy.negctrl() @ prog.gate(reg, "x")
     oqpy.pow(1 / 2) @ prog.gate(oqpy.PhysicalQubits[2], "t")
     oqpy.inv() @ prog.gate(oqpy.PhysicalQubits[3], "rz")
     oqpy.ctrl() @ oqpy.pow(1 / 2) @ oqpy.inv() @ prog.gate(reg, "x")
@@ -2281,6 +2282,7 @@ def test_gate_modifiers():
         int[32] i = 5;
         frame f1;
         ctrl @ t $1, $2;
+        negctrl @ x $1, $2;
         pow(0.5) @ t $2;
         inv @ rz $3;
         ctrl @ pow(0.5) @ inv @ x $1, $2;

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2317,6 +2317,13 @@ def test_gate_modifiers_second_method():
         neg_controls=[qreg[0], qreg[1], qreg[0]],
     )
 
+    with pytest.raises(ValueError):
+        prog.gate(qreg[2], "t", controls=qreg[2])
+    with pytest.raises(ValueError):
+        prog.gate(qreg[2], "x", neg_controls=qreg[2])
+    with pytest.raises(ValueError):
+        prog.gate(qreg[1], "x", controls=qreg[2], neg_controls=qreg[2])
+
     expected = textwrap.dedent(
         """
         OPENQASM 3.0;

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2208,8 +2208,8 @@ def test_gate_modifiers():
     prog.gate(qreg[2], "t", controls=qreg[1])
     prog.gate(qreg[2], "x", neg_controls=qreg[1])
     prog.gate(qreg[3], "rz", inv=True)
-    prog.gate(qreg[2], "t", pow=0.5)
-    prog.gate(qreg[0], "x", inv=True, pow=oqpy.IntVar(5, "i") / 2)
+    prog.gate(qreg[2], "t", exp=0.5)
+    prog.gate(qreg[0], "x", inv=True, exp=oqpy.IntVar(5, "i") / 2)
 
     prog.gate(
         six_qubit_reg[-1],
@@ -2217,7 +2217,7 @@ def test_gate_modifiers():
         controls=six_qubit_reg[0:2],
         neg_controls=six_qubit_reg[2:5],
         inv=True,
-        pow=1 / 2,
+        exp=1 / 2,
     )
 
     prog.gate(

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2336,3 +2336,4 @@ def test_include():
     ).strip()
 
     assert prog.to_qasm() == expected
+    _check_respects_type_hints(prog)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2205,8 +2205,8 @@ def test_gate_modifiers():
     qreg = [oqpy.PhysicalQubits[i] for i in range(0, 8)]
     six_qubit_reg = [qreg[i] for i in [1, 4, 7, 2, 3, 5]]
 
-    prog.gate(qreg[2], "t", controls=qreg[1])
-    prog.gate(qreg[2], "x", neg_controls=qreg[1])
+    prog.gate(qreg[2], "t", control=qreg[1])
+    prog.gate(qreg[2], "x", neg_control=qreg[1])
     prog.gate(qreg[3], "rz", inv=True)
     prog.gate(qreg[2], "t", exp=0.5)
     prog.gate(qreg[0], "x", inv=True, exp=oqpy.IntVar(5, "i") / 2)
@@ -2214,8 +2214,8 @@ def test_gate_modifiers():
     prog.gate(
         six_qubit_reg[-1],
         "x",
-        controls=six_qubit_reg[0:2],
-        neg_controls=six_qubit_reg[2:5],
+        control=six_qubit_reg[0:2],
+        neg_control=six_qubit_reg[2:5],
         inv=True,
         exp=1 / 2,
     )
@@ -2223,16 +2223,16 @@ def test_gate_modifiers():
     prog.gate(
         qreg[6],
         "rz1",
-        controls=[qreg[2], qreg[4], qreg[5]],
-        neg_controls=[qreg[0], qreg[1], qreg[0]],
+        control=[qreg[2], qreg[4], qreg[5]],
+        neg_control=[qreg[0], qreg[1], qreg[0]],
     )
 
     with pytest.raises(ValueError):
-        prog.gate(qreg[2], "t", controls=qreg[2])
+        prog.gate(qreg[2], "t", control=qreg[2])
     with pytest.raises(ValueError):
-        prog.gate(qreg[2], "x", neg_controls=qreg[2])
+        prog.gate(qreg[2], "x", neg_control=qreg[2])
     with pytest.raises(ValueError):
-        prog.gate(qreg[1], "x", controls=qreg[2], neg_controls=qreg[2])
+        prog.gate(qreg[1], "x", control=qreg[2], neg_control=qreg[2])
 
     expected = textwrap.dedent(
         """
@@ -2285,9 +2285,9 @@ def test_gate_declarations():
     with oqpy.gate(prog, q, "t"):
         prog.gate(q, "rz", oqpy.pi / 4)
     with oqpy.gate(prog, [q, r], "cnot"):
-        prog.gate(r, "x", controls=q)
+        prog.gate(r, "x", control=q)
     with oqpy.gate(prog, [q, r], "ncphaseshift", [oqpy.AngleVar(name="theta")]) as theta:
-        prog.gate(r, "phase", theta, neg_controls=[q])
+        prog.gate(r, "phase", theta, neg_control=[q])
 
     prog.gate(oqpy.PhysicalQubits[1], "t")
     prog.gate(oqpy.PhysicalQubits[2], "t")

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2236,6 +2236,9 @@ def test_gate_modifiers():
 
     ctrl(qreg[2]) @ prog.gate(qreg[0], "x", controls=[qreg[1]])
 
+    with pytest.raises(ValueError):
+        oqpy.ctrl(qreg[2]) @ oqpy.negctrl(qreg[2])
+
     expected = textwrap.dedent(
         """
         OPENQASM 3.0;

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -489,6 +489,8 @@ def test_add_incomptible_type():
 def test_measure_reset_pragma():
     prog = Program()
     q = PhysicalQubits[0]
+    with pytest.raises(AssertionError):
+        reg = PhysicalQubits[0:1]
     c = BitVar(name="c")
     prog.reset(q)
     prog.pragma("CLASSIFIER linear")

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2260,13 +2260,14 @@ def test_gate_declarations():
 
 def test_gate_modifiers():
     prog = oqpy.Program()
-    reg = [oqpy.PhysicalQubits[i] for i in range(1, 3)]
+    two_qubit_reg = [oqpy.PhysicalQubits[i] for i in range(1, 3)]
+    six_qubit_reg = [oqpy.PhysicalQubits[i] for i in [1, 4, 7, 2, 3, 5]]
 
-    oqpy.ctrl() @ prog.gate(reg, "t")
-    oqpy.negctrl() @ prog.gate(reg, "x")
+    oqpy.ctrl() @ prog.gate(two_qubit_reg, "t")
+    oqpy.negctrl() @ prog.gate(two_qubit_reg, "x")
     oqpy.pow(1 / 2) @ prog.gate(oqpy.PhysicalQubits[2], "t")
     oqpy.inv() @ prog.gate(oqpy.PhysicalQubits[3], "rz")
-    oqpy.ctrl() @ oqpy.pow(1 / 2) @ oqpy.inv() @ prog.gate(reg, "x")
+    oqpy.ctrl(2) @ oqpy.pow(1 / 2) @ oqpy.negctrl(3) @ oqpy.inv() @ prog.gate(six_qubit_reg, "x")
 
     mod = oqpy.inv() @ oqpy.pow(oqpy.IntVar(5, "i") / 2)
     mod @ prog.gate(oqpy.PhysicalQubits[0], "x")
@@ -2285,7 +2286,7 @@ def test_gate_modifiers():
         negctrl @ x $1, $2;
         pow(0.5) @ t $2;
         inv @ rz $3;
-        ctrl @ pow(0.5) @ inv @ x $1, $2;
+        ctrl(2) @ pow(0.5) @ negctrl(3) @ inv @ x $1, $4, $7, $2, $3, $5;
         inv @ pow(i / 2) @ x $0;
         shift_frequency(f1, 1000000.0);
         """


### PR DESCRIPTION
OQPyGateModifier (#61) is problably unnecessary complex. This PR keeps only the argument method.

Adds 4 keyword arguments to `gate`:
- controls
- neg_controls
- inv
- exp

