### PR TITLE
Add .include method

### DIFF
--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -523,6 +523,14 @@ class Program:
         self._add_statement(ast.Pragma(command))
         return self
 
+    def include(self, path: str) -> Program:
+        """Add an include statement."""
+        if len(self.stack) != 1:
+            # cf. https://openqasm.com/language/comments.html#included-files
+            raise RuntimeError("Include statements must be global")
+        self._add_statement(ast.Include(path))
+        return self
+
     def _do_assignment(self, var: AstConvertible, op: str, value: AstConvertible) -> None:
         """Helper function for variable assignment operations."""
         if isinstance(var, classical_types.DurationVar):

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2249,3 +2249,20 @@ def test_gate_declarations():
     ).strip()
 
     assert prog.to_qasm() == expected
+
+
+def test_include():
+    prog = Program()
+    prog.include("foo.qasm")
+    prog.declare(IntVar(0, "i"))
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        include "foo.qasm";
+        int[32] i = 0;
+        """
+    ).strip()
+
+    assert prog.to_qasm() == expected
+


### PR DESCRIPTION
This adds a `Program.include` method. Note that like `pragma`, it is illegal to have include statements outside of the program toplevel.