### PR TITLE
Qubit and BitVar supports get item

### DIFF
--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -394,6 +394,21 @@ class OQPyBinaryExpression(OQPyExpression):
         return ast.BinaryExpression(self.op, to_ast(program, self.lhs), to_ast(program, self.rhs))
 
 
+class OQIndexExpression(OQPyExpression):
+    """An oqpy expression corresponding to an index expression."""
+
+    def __init__(self, collection: AstConvertible, index: AstConvertible, type: ast.ClassicalType):
+        self.collection = collection
+        self.index = index
+        self.type = type
+
+    def to_ast(self, program: Program) -> ast.IndexExpression:
+        """Converts this oqpy index expression into an ast node."""
+        return ast.IndexExpression(
+            collection=to_ast(program, self.collection), index=[to_ast(program, self.index)]
+        )
+
+
 class Var(ABC):
     """Abstract base class for both classical and quantum variables."""
 

--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -397,21 +397,6 @@ class OQPyBinaryExpression(OQPyExpression):
         return ast.BinaryExpression(self.op, to_ast(program, self.lhs), to_ast(program, self.rhs))
 
 
-class OQIndexExpression(OQPyExpression):
-    """An oqpy expression corresponding to an index expression."""
-
-    def __init__(self, collection: AstConvertible, index: AstConvertible, type: ast.ClassicalType):
-        self.collection = collection
-        self.index = index
-        self.type = type
-
-    def to_ast(self, program: Program) -> ast.IndexExpression:
-        """Converts this oqpy index expression into an ast node."""
-        return ast.IndexExpression(
-            collection=to_ast(program, self.collection), index=[to_ast(program, self.index)]
-        )
-
-
 class Var(ABC):
     """Abstract base class for both classical and quantum variables."""
 

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -293,7 +293,7 @@ class BitVar(_SizedVar):
 
     def __getitem__(self, index: AstConvertible) -> OQIndexExpression:
         self._validate_getitem_index(index)
-        return OQIndexExpression(collection=self, index=index, type=self.type_cls())
+        return OQIndexExpression(collection=self, index=index, type_=self.type_cls())
 
 
 class ComplexVar(_ClassicalVar):
@@ -399,7 +399,7 @@ class ArrayVar(_ClassicalVar):
         )
 
     def __getitem__(self, index: AstConvertible) -> OQIndexExpression:
-        return OQIndexExpression(collection=self, index=index, type=self.base_type().type_cls())
+        return OQIndexExpression(collection=self, index=index, type_=self.base_type().type_cls())
 
 
 class OQIndexExpression(OQPyExpression):

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -408,7 +408,7 @@ class OQIndexExpression(OQPyExpression):
     def __init__(self, collection: AstConvertible, index: AstConvertible, type_: ast.ClassicalType):
         self.collection = collection
         self.index = index
-        self.type = type
+        self.type = type_
 
     def to_ast(self, program: Program) -> ast.IndexExpression:
         """Converts this oqpy index expression into an ast node."""

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -405,7 +405,7 @@ class ArrayVar(_ClassicalVar):
 class OQIndexExpression(OQPyExpression):
     """An oqpy expression corresponding to an index expression."""
 
-    def __init__(self, collection: AstConvertible, index: AstConvertible, type: ast.ClassicalType):
+    def __init__(self, collection: AstConvertible, index: AstConvertible, type_: ast.ClassicalType):
         self.collection = collection
         self.index = index
         self.type = type

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -287,6 +287,8 @@ class BitVar(_SizedVar):
                 )
             else:
                 raise IndexError("list index out of range.")
+        elif isinstance(idx, OQPyExpression) and isinstance(idx.type, (ast.IntType, ast.UintType)):
+            return OQIndexExpression(collection=self, index=idx)
         else:
             raise IndexError("The list index must be an integer.")
 

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -34,6 +34,7 @@ from openqasm3.visitor import QASMVisitor
 from oqpy import classical_types, quantum_types
 from oqpy.base import (
     AstConvertible,
+    OQIndexExpression,
     Var,
     expr_matches,
     map_to_ast,
@@ -483,7 +484,10 @@ class Program:
         self, qubits: AstConvertible | Iterable[AstConvertible], name: str, *args: Any
     ) -> Program:
         """Apply a gate to a qubit or set of qubits."""
-        if isinstance(qubits, quantum_types.Qubit):
+        if isinstance(qubits, quantum_types.Qubit) or (
+            isinstance(qubits, OQIndexExpression)
+            and isinstance(qubits.collection, quantum_types.Qubit)
+        ):
             qubits = [qubits]
         assert isinstance(qubits, Iterable)
         self._add_statement(
@@ -546,7 +550,7 @@ class Program:
 
     def set(
         self,
-        var: classical_types._ClassicalVar | classical_types.OQIndexExpression,
+        var: classical_types._ClassicalVar | OQIndexExpression,
         value: AstConvertible,
     ) -> Program:
         """Set a variable value."""

--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -34,7 +34,6 @@ from openqasm3.visitor import QASMVisitor
 from oqpy import classical_types, quantum_types
 from oqpy.base import (
     AstConvertible,
-    OQIndexExpression,
     Var,
     expr_matches,
     map_to_ast,
@@ -484,10 +483,7 @@ class Program:
         self, qubits: AstConvertible | Iterable[AstConvertible], name: str, *args: Any
     ) -> Program:
         """Apply a gate to a qubit or set of qubits."""
-        if isinstance(qubits, quantum_types.Qubit) or (
-            isinstance(qubits, OQIndexExpression)
-            and isinstance(qubits.collection, quantum_types.Qubit)
-        ):
+        if isinstance(qubits, (quantum_types.Qubit, quantum_types.IndexedQubitArray)):
             qubits = [qubits]
         assert isinstance(qubits, Iterable)
         self._add_statement(
@@ -558,7 +554,7 @@ class Program:
 
     def set(
         self,
-        var: classical_types._ClassicalVar | OQIndexExpression,
+        var: classical_types._ClassicalVar | classical_types.OQIndexExpression,
         value: AstConvertible,
     ) -> Program:
         """Set a variable value."""

--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -39,7 +39,7 @@ class Qubit(Var):
     def __init__(
         self,
         name: str,
-        size: int = None,
+        size: Optional[int] = None,
         needs_declaration: bool = True,
         annotations: Sequence[str | tuple[str, str]] = (),
     ):

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -30,8 +30,7 @@ from openpulse.printer import dumps
 
 import oqpy
 from oqpy import *
-from oqpy.base import OQPyExpression, expr_matches, logical_and, logical_or
-from oqpy.classical_types import OQIndexExpression
+from oqpy.base import OQPyExpression, expr_matches, logical_and, logical_or, OQIndexExpression
 from oqpy.quantum_types import PhysicalQubits
 from oqpy.timing import OQDurationLiteral
 
@@ -2261,3 +2260,26 @@ def test_gate_declarations():
     ).strip()
 
     assert prog.to_qasm() == expected
+
+
+def test_qubit_array():
+    prog = oqpy.Program()
+    q = oqpy.Qubit("q", size=2)
+    prog.gate(q[0], "h")
+    prog.gate([q[0], q[1]], "cnot")
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        qubit[2] q;
+        h q[0];
+        cnot q[0], q[1];
+        """
+    ).strip()
+
+    assert prog.to_qasm() == expected
+
+    with pytest.raises(TypeError):
+        prog = oqpy.Program()
+        q = oqpy.Qubit("q")
+        prog.gate(q[0], "h")

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -30,7 +30,8 @@ from openpulse.printer import dumps
 
 import oqpy
 from oqpy import *
-from oqpy.base import OQPyExpression, expr_matches, logical_and, logical_or, OQIndexExpression
+from oqpy.base import OQPyExpression, expr_matches, logical_and, logical_or
+from oqpy.classical_types import OQIndexExpression
 from oqpy.quantum_types import PhysicalQubits
 from oqpy.timing import OQDurationLiteral
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -31,6 +31,7 @@ from openpulse.printer import dumps
 import oqpy
 from oqpy import *
 from oqpy.base import OQPyExpression, expr_matches, logical_and, logical_or
+from oqpy.classical_types import OQIndexExpression
 from oqpy.quantum_types import PhysicalQubits
 from oqpy.timing import OQDurationLiteral
 
@@ -160,7 +161,7 @@ def test_variable_declaration():
         """
     ).strip()
 
-    assert isinstance(arr[14], BitVar)
+    assert isinstance(arr[14], OQIndexExpression)
     assert prog.to_qasm() == expected
     _check_respects_type_hints(prog)
 
@@ -2221,7 +2222,12 @@ def test_invalid_gates():
 def test_gate_declarations():
     prog = oqpy.Program()
     q = oqpy.Qubit("q", needs_declaration=False)
-    with oqpy.gate(prog, q, "u", [oqpy.AngleVar(name="alpha"), oqpy.AngleVar(name="beta"), oqpy.AngleVar(name="gamma")]) as (alpha, beta, gamma):
+    with oqpy.gate(
+        prog,
+        q,
+        "u",
+        [oqpy.AngleVar(name="alpha"), oqpy.AngleVar(name="beta"), oqpy.AngleVar(name="gamma")],
+    ) as (alpha, beta, gamma):
         prog.gate(q, "a", alpha)
         prog.gate(q, "b", beta)
         prog.gate(q, "c", gamma)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -126,6 +126,9 @@ def test_variable_declaration():
     prog = Program(version=None)
     prog.declare(vars)
     prog.set(arr[1], 0)
+    index = IntVar(2, "index")
+    prog.set(arr[index], 1)
+    prog.set(arr[index + 1], 0)
 
     with pytest.raises(IndexError):
         prog.set(arr[40], 2)
@@ -142,6 +145,7 @@ def test_variable_declaration():
 
     expected = textwrap.dedent(
         """
+        int[32] index = 2;
         bool b = true;
         int[32] i = -4;
         uint[32] u = 5;
@@ -151,6 +155,8 @@ def test_variable_declaration():
         bit[20] arr;
         bit c;
         arr[1] = 0;
+        arr[index] = 1;
+        arr[index + 1] = 0;
         """
     ).strip()
 


### PR DESCRIPTION
Closes https://github.com/openqasm/oqpy/issues/8 and https://github.com/openqasm/oqpy/issues/62

Description of change:
- Move `OQIndexExpression ` to `oqpy.base`
- Support indexing in Qubit class. `__getitem__` returns an `OQIndexExpression `
- Remove `QubitArray` class
- Support variable indexing in BitVar (the changes in this PR include the ones in https://github.com/openqasm/oqpy/pull/63)