### PR TITLE
update qubit array test

### DIFF
--- a/oqpy/quantum_types.py
+++ b/oqpy/quantum_types.py
@@ -55,6 +55,8 @@ class Qubit(Var):
 
     def make_declaration_statement(self, program: Program) -> ast.Statement:
         """Make an ast statement that declares the OQpy variable."""
+        if self.size == 0:
+            raise ValueError("The size of the qubit register cannot be zero.")
         decl = ast.QubitDeclaration(
             ast.Identifier(self.name),
             size=ast.IntegerLiteral(self.size) if self.size else None,

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2307,3 +2307,9 @@ def test_qubit_array():
 
     assert prog.to_qasm() == expected
     _check_respects_type_hints(prog)
+
+    prog_with_errors = oqpy.Program()
+    q0 = oqpy.Qubit("q0", size=0)
+    prog_with_errors.gate(q0, "h")
+    with pytest.raises(ValueError):
+        prog_with_errors.to_qasm()


### PR DESCRIPTION
Previous PR was not checking type hints (via `_check_respects_type_hints`). We missed that the correct AST node to use was `IndexedIdentifier` instead of `IndexedExpression`. 

This PR updates IndexedQubitArray and the corresponding test.