### PR TITLE
Keep the arg names in OQFunctionCall

### DIFF
--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -24,6 +24,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Iterable,
     Optional,
     Sequence,
     Type,
@@ -423,7 +424,7 @@ class OQFunctionCall(OQPyExpression):
     def __init__(
         self,
         identifier: Union[str, ast.Identifier],
-        args: dict[str, AstConvertible],
+        args: Iterable[AstConvertible],
         return_type: Optional[ast.ClassicalType],
         extern_decl: ast.ExternDeclaration | None = None,
         subroutine_decl: ast.SubroutineDefinition | None = None,
@@ -456,4 +457,5 @@ class OQFunctionCall(OQPyExpression):
             program.externs[self.identifier.name] = self.extern_decl
         if self.subroutine_decl is not None:
             program._add_subroutine(self.identifier.name, self.subroutine_decl)
-        return ast.FunctionCall(self.identifier, map_to_ast(program, list(self.args.values())))
+        args = list(self.args.values()) if isinstance(self.args, dict) else self.args
+        return ast.FunctionCall(self.identifier, map_to_ast(program, args))

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -424,7 +424,7 @@ class OQFunctionCall(OQPyExpression):
     def __init__(
         self,
         identifier: Union[str, ast.Identifier],
-        args: Iterable[AstConvertible],
+        args: Union[Iterable[AstConvertible], dict[Any, AstConvertible]],
         return_type: Optional[ast.ClassicalType],
         extern_decl: ast.ExternDeclaration | None = None,
         subroutine_decl: ast.SubroutineDefinition | None = None,
@@ -433,7 +433,8 @@ class OQFunctionCall(OQPyExpression):
 
         Args:
             identifier: The function name.
-            args: The function arguments.
+            args: The function arguments. If passed as a dict, the values are used when
+                creating the FunctionCall ast node.
             return_type: The type returned by the function call. If none, returns nothing.
             extern_decl: An optional extern declaration ast node. If present,
                 this extern declaration will be added to the top of the program

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -457,5 +457,5 @@ class OQFunctionCall(OQPyExpression):
             program.externs[self.identifier.name] = self.extern_decl
         if self.subroutine_decl is not None:
             program._add_subroutine(self.identifier.name, self.subroutine_decl)
-        args = list(self.args.values()) if isinstance(self.args, dict) else self.args
+        args = self.args.values() if isinstance(self.args, dict) else self.args
         return ast.FunctionCall(self.identifier, map_to_ast(program, args))

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -24,7 +24,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Iterable,
     Optional,
     Sequence,
     Type,
@@ -424,7 +423,7 @@ class OQFunctionCall(OQPyExpression):
     def __init__(
         self,
         identifier: Union[str, ast.Identifier],
-        args: Iterable[AstConvertible],
+        args: dict[str, AstConvertible],
         return_type: Optional[ast.ClassicalType],
         extern_decl: ast.ExternDeclaration | None = None,
         subroutine_decl: ast.SubroutineDefinition | None = None,
@@ -457,4 +456,4 @@ class OQFunctionCall(OQPyExpression):
             program.externs[self.identifier.name] = self.extern_decl
         if self.subroutine_decl is not None:
             program._add_subroutine(self.identifier.name, self.subroutine_decl)
-        return ast.FunctionCall(self.identifier, map_to_ast(program, self.args))
+        return ast.FunctionCall(self.identifier, map_to_ast(program, list(self.args.values())))

--- a/oqpy/pulse.py
+++ b/oqpy/pulse.py
@@ -75,7 +75,9 @@ class FrameVar(_ClassicalVar):
             init_expression = None
         else:
             assert frequency is not None
-            init_expression = OQFunctionCall("newframe", [port, frequency, phase], ast.FrameType)
+            init_expression = OQFunctionCall(
+                "newframe", {"port": port, "frequency": frequency, "phase": phase}, ast.FrameType
+            )
         super().__init__(
             init_expression, name, needs_declaration=needs_declaration, annotations=annotations
         )

--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -153,7 +153,7 @@ def subroutine(
         program.externs.update(inner_prog.externs)
         return OQFunctionCall(
             identifier,
-            args,
+            {k: v for k, v in zip(argnames[1:], args)},
             return_type,
             subroutine_decl=stmt,
         )
@@ -218,7 +218,9 @@ def declare_extern(
         for i, a in enumerate(call_args):
             if type(arg_types[i]) == ast.DurationType:
                 new_args[i] = convert_float_to_duration(a)
-        return OQFunctionCall(name, new_args, return_type, extern_decl=extern_decl)
+        return OQFunctionCall(
+            name, {k: v for k, v in zip(arg_names, new_args)}, return_type, extern_decl=extern_decl
+        )
 
     return call_extern
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -328,6 +328,7 @@ def test_non_trivial_array_access():
 
     assert prog.to_qasm() == expected
     _check_respects_type_hints(prog)
+    assert expr_matches(frame.init_expression.args["port"], port)
 
 
 def test_non_trivial_variable_declaration():
@@ -941,6 +942,8 @@ def test_box_and_timings():
     assert prog.to_qasm() == expected
     # Todo: box only currently technically allows QuantumStatements (i.e. gates)
     _check_respects_type_hints(prog, ["body"])
+    assert expr_matches(constant(100e-9, 0.5).args["length"], convert_float_to_duration(100e-9))
+    assert expr_matches(constant(100e-9, 0.5).args["iq"], 0.5)
 
 
 def test_play_capture():
@@ -1037,6 +1040,9 @@ def test_declare_extern():
     ).strip()
 
     assert program.to_qasm() == expected
+    assert "x" in arctan(f, f).args
+    assert expr_matches(arctan(f, i).args["x"], f)
+    assert expr_matches(arctan(f, i).args["y"], i)
 
 
 def test_defcals():

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -387,9 +387,10 @@ def test_binary_expressions():
     b2 = BoolVar(True, "b2")
     b3 = BoolVar(False, "b3")
     d = DurationVar(5e-9, "d")
+    z = ComplexVar(1.2j, "z")
     prog.set(i, 2 * (i + j))
     prog.set(j, 2 % (2 - i) % 2)
-    prog.set(j, j * 1j)
+    prog.set(z, z * 1j)
     prog.set(j, 1 + oqpy.pi)
     prog.set(j, 1 / oqpy.pi**2 / 2 + 2**oqpy.pi)
     prog.set(j, -oqpy.pi * oqpy.pi - i**j)
@@ -420,13 +421,13 @@ def test_binary_expressions():
     prog.set(f, d / convert_float_to_duration(1))
 
     with pytest.raises(ValueError):
-        prog.set(f, "a" * i)
+        prog.set(z, "a" * i)
     with pytest.raises(TypeError):
-        prog.set(f, b1 * 2)
+        prog.set(z, b1 * 2)
     with pytest.raises(TypeError):
-        prog.set(b1, b1 / 2)
+        prog.set(z, b1 / 2)
     with pytest.raises(TypeError):
-        prog.set(b1, logical_and(True, False))
+        prog.set(z, logical_and(True, False))
     with pytest.raises(TypeError):
         OQPyExpression()._to_unary("-", 1)
     with pytest.raises(TypeError):
@@ -439,6 +440,7 @@ def test_binary_expressions():
         OPENQASM 3.0;
         int[32] i = 5;
         int[32] j = 2;
+        complex[float[64]] z = 1.2im;
         int[32] k = 0;
         bool b1 = false;
         bool b2 = true;
@@ -447,7 +449,7 @@ def test_binary_expressions():
         float[64] f = 0.0;
         i = 2 * (i + j);
         j = 2 % (2 - i) % 2;
-        j = j * 1.0im;
+        z = z * 1.0im;
         j = 1 + pi;
         j = 1 / pi ** 2 / 2 + 2 ** pi;
         j = -pi * pi - i ** j;

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -387,10 +387,9 @@ def test_binary_expressions():
     b2 = BoolVar(True, "b2")
     b3 = BoolVar(False, "b3")
     d = DurationVar(5e-9, "d")
-    z = ComplexVar(1.2j, "z")
     prog.set(i, 2 * (i + j))
     prog.set(j, 2 % (2 - i) % 2)
-    prog.set(z, z * 1j)
+    prog.set(j, j * 1j)
     prog.set(j, 1 + oqpy.pi)
     prog.set(j, 1 / oqpy.pi**2 / 2 + 2**oqpy.pi)
     prog.set(j, -oqpy.pi * oqpy.pi - i**j)
@@ -421,13 +420,13 @@ def test_binary_expressions():
     prog.set(f, d / convert_float_to_duration(1))
 
     with pytest.raises(ValueError):
-        prog.set(z, "a" * i)
+        prog.set(f, "a" * i)
     with pytest.raises(TypeError):
-        prog.set(z, b1 * 2)
+        prog.set(f, b1 * 2)
     with pytest.raises(TypeError):
-        prog.set(z, b1 / 2)
+        prog.set(b1, b1 / 2)
     with pytest.raises(TypeError):
-        prog.set(z, logical_and(True, False))
+        prog.set(b1, logical_and(True, False))
     with pytest.raises(TypeError):
         OQPyExpression()._to_unary("-", 1)
     with pytest.raises(TypeError):
@@ -440,7 +439,6 @@ def test_binary_expressions():
         OPENQASM 3.0;
         int[32] i = 5;
         int[32] j = 2;
-        complex[float[64]] z = 1.2im;
         int[32] k = 0;
         bool b1 = false;
         bool b2 = true;
@@ -449,7 +447,7 @@ def test_binary_expressions():
         float[64] f = 0.0;
         i = 2 * (i + j);
         j = 2 % (2 - i) % 2;
-        z = z * 1.0im;
+        j = j * 1.0im;
         j = 1 + pi;
         j = 1 / pi ** 2 / 2 + 2 ** pi;
         j = -pi * pi - i ** j;


### PR DESCRIPTION
OQFunctionCall now stores a dict of argument values indexed by the argument names. 

Waveforms can now be modified by `Program.undeclared_vars["wf_name"].args["argname"] = value` before calling `to_ast()`