### PR TITLE
feat: make Range iterable

### DIFF
--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -181,6 +181,11 @@ class OQPyExpression:
         )
 
 
+class OqpyIterable:
+    def __iter__(self):
+        raise Exception("Cannot iterate until runtime.")
+
+
 def _get_type(val: AstConvertible) -> Optional[ast.ClassicalType]:
     if isinstance(val, OQPyExpression):
         return val.type
@@ -521,7 +526,7 @@ def to_ast(program: Program, item: AstConvertible) -> ast.Expression:
             to_ast(program, item.stop - 1) if item.stop is not None else None,
             to_ast(program, item.step) if item.step is not None else None,
         )
-    if isinstance(item, Iterable):
+    if isinstance(item, Iterable) and not isinstance(item, OqpyIterable):
         return ast.ArrayLiteral([to_ast(program, i) for i in item])
     if isinstance(item, ast.Expression):
         return item

--- a/oqpy/control_flow.py
+++ b/oqpy/control_flow.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Iterable, Iterator, Optional, TypeVar, overloa
 
 from openpulse import ast
 
-from oqpy.base import OQPyExpression, to_ast
+from oqpy.base import OQPyExpression, OqpyIterable, to_ast
 from oqpy.classical_types import (
     AstConvertible,
     DurationVar,
@@ -124,7 +124,7 @@ def ForIn(
         # A range can only be iterated over integers.
         assert identifier_type is IntVar, "A range can only be looped over an integer."
         set_declaration = convert_range(program, iterator)
-    elif isinstance(iterator, Iterable):
+    elif isinstance(iterator, Iterable) and not isinstance(iterator, OqpyIterable):
         if identifier_type is DurationVar:
             iterator = (convert_float_to_duration(i) for i in iterator)
 
@@ -138,7 +138,7 @@ def ForIn(
     program._add_statement(stmt)
 
 
-class Range:
+class Range(OqpyIterable):
     """AstConvertible which creates an integer range.
 
     Unlike builtin python range, this allows the components to be AstConvertible,


### PR DESCRIPTION
Draft PR to demonstrate typing fix that removes IDE warning (`Expected type 'collections.Iterable', got 'Range' instead`) for autoqasm syntax `for _ in aq.range(n)` (where `aq.range(n)` gives an oqpy `Range` object).

If `Range` is not meant to be an "iterable", there may be a fix on the autoqasm side