### PR TITLE
Allow custom ExternArgument in extern declaration

### DIFF
--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -173,7 +173,7 @@ def subroutine(
 
 def declare_extern(
     name: str,
-    args: list[tuple[str, ast.ClassicalType]],
+    args: list[tuple[str, ast.ClassicalType | ast.ExternArgument]],
     return_type: Optional[ast.ClassicalType] = None,
     annotations: Sequence[str | tuple[str, str]] = (),
 ) -> Callable[..., OQFunctionCall]:
@@ -194,7 +194,7 @@ def declare_extern(
     arg_types = list(zip(*(args)))[1] if args else []
     extern_decl = ast.ExternDeclaration(
         ast.Identifier(name),
-        [ast.ExternArgument(type=t) for t in arg_types],
+        [ast.ExternArgument(type=t) if isinstance(t, ast.ClassicalType) else t for t in arg_types],
         return_type,
     )
     extern_decl.annotations = make_annotations(annotations)
@@ -236,7 +236,7 @@ def declare_extern(
 
 def declare_waveform_generator(
     name: str,
-    argtypes: list[tuple[str, ast.ClassicalType]],
+    argtypes: list[tuple[str, ast.ClassicalType | ast.ExternArgument]],
     annotations: Sequence[str | tuple[str, str]] = (),
 ) -> Callable[..., OQFunctionCall]:
     """Create a function which generates waveforms using a specified name and argument signature."""

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -1024,6 +1024,20 @@ def test_declare_extern():
     # Test an extern with no input and no output
     fire_bazooka = declare_extern("fire_bazooka", [])
 
+    # Test an extern with readonly array
+    print_array = declare_extern(
+        "print_array",
+        [
+            (
+                "arr",
+                ast.ExternArgument(
+                    type=ast.ArrayReferenceType(int32, ast.IntegerLiteral(1)),
+                    access=ast.AccessControl["readonly"],
+                ),
+            ),
+        ],
+    )
+
     f = oqpy.FloatVar(name="f", init_expression=0.0)
     i = oqpy.IntVar(name="i", init_expression=5)
 
@@ -1032,6 +1046,7 @@ def test_declare_extern():
     program.set(i, time())
     program.do_expression(set_global_voltage(i))
     program.do_expression(fire_bazooka())
+    program.do_expression(print_array([0, 1, 2]))
 
     expected = textwrap.dedent(
         """
@@ -1041,6 +1056,7 @@ def test_declare_extern():
         extern time() -> int[32];
         extern set_voltage(int[32]);
         extern fire_bazooka();
+        extern print_array(readonly array[int[32], #dim=1]);
         float[64] f = 0.0;
         int[32] i = 5;
         f = sqrt(f);
@@ -1048,6 +1064,7 @@ def test_declare_extern():
         i = time();
         set_voltage(i);
         fire_bazooka();
+        print_array({0, 1, 2});
         """
     ).strip()
 


### PR DESCRIPTION
This is useful if people want to specify ArrayReferenceType as an argument to an extern function. ArrayReferenceType require an explicit Access modifier (mutable or readonly). Since this is just one edge case, we can let users still specify just the type for all other extern declarations.

I have added a test that demos its usage.