### PR TITLE
Raise an exception for delays or boxes with known negative duration

### DIFF
--- a/oqpy/program.py
+++ b/oqpy/program.py
@@ -423,7 +423,7 @@ class Program:
         """Apply a delay to a set of qubits or frames."""
         if not isinstance(qubits_or_frames, Iterable):
             qubits_or_frames = [qubits_or_frames]
-        ast_duration = to_ast(self, convert_float_to_duration(time))
+        ast_duration = to_ast(self, convert_float_to_duration(time, require_nonnegative=True))
         ast_qubits_or_frames = map_to_ast(self, qubits_or_frames)
         self._add_statement(ast.DelayInstruction(ast_duration, ast_qubits_or_frames))
         return self

--- a/oqpy/timing.py
+++ b/oqpy/timing.py
@@ -60,9 +60,17 @@ def make_duration(time: AstConvertible) -> HasToAst:
     return convert_float_to_duration(time)
 
 
-def convert_float_to_duration(time: AstConvertible) -> HasToAst:
-    """Make value into an expression representing a duration."""
+def convert_float_to_duration(time: AstConvertible, require_nonnegative: bool = False) -> HasToAst:
+    """Make value into an expression representing a duration.
+
+    Args:
+      time: the time
+      require_nonnegative: if True, raise an exception if the time value is known to
+        be negative.
+    """
     if isinstance(time, (float, int)):
+        if require_nonnegative and time < 0:
+            raise ValueError(f"Expected a non-negative duration, but got {time}")
         return OQDurationLiteral(time)
     if isinstance(time, OQPyExpression):
         if isinstance(time.type, (ast.UintType, ast.IntType, ast.FloatType)):

--- a/oqpy/timing.py
+++ b/oqpy/timing.py
@@ -43,7 +43,7 @@ __all__ = ["Box", "convert_float_to_duration", "convert_float_to_duration", "mak
 def Box(program: Program, duration: AstConvertible | None = None) -> Iterator[None]:
     """Creates a section of the program with a specified duration."""
     if duration is not None:
-        duration = convert_float_to_duration(duration)
+        duration = convert_float_to_duration(duration, require_nonnegative=True)
     program._push()
     yield
     state = program._pop()

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2579,3 +2579,11 @@ def test_function_call(args, assigns_to, expected):
     prog.function_call("my_function", args, assigns_to)
     assert prog.to_qasm() == expected
     _check_respects_type_hints(prog)
+
+
+def test_delay_with_negative_duration():
+    prog = Program()
+    port = oqpy.PortVar(name="my_port")
+    frame = oqpy.FrameVar(name="my_frame", port=port, frequency=1e9, phase=0)
+    with pytest.raises(ValueError, match="Expected a non-negative duration, but got -4e-09"):
+        prog.delay(-4e-9, frame)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2587,3 +2587,12 @@ def test_delay_with_negative_duration():
     frame = oqpy.FrameVar(name="my_frame", port=port, frequency=1e9, phase=0)
     with pytest.raises(ValueError, match="Expected a non-negative duration, but got -4e-09"):
         prog.delay(-4e-9, frame)
+
+
+def test_box_with_negative_duration():
+    prog = Program()
+    with pytest.raises(ValueError, match="Expected a non-negative duration, but got -4e-09"):
+        with Box(prog, -4e-9):
+            pass
+
+


### PR DESCRIPTION
In general, OpenQASM `duration` values may be negative. But the duration of a `delay` cannot be negative. This PR detects negative durations in the common case where the time is known at program construction time, and raises an exception. We also enable this for `box` durations.