### PR TITLE
Allow expr_matches to better handle presence of extra data

### DIFF
--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -180,7 +180,7 @@ class OQPyExpression:
             "the equality of expressions using == instead of expr_matches."
         )
 
-    def _expr_matches(self, other) -> bool:
+    def _expr_matches(self, other: Any) -> bool:
         """Called by expr_matches to compare expression instances."""
         if not isinstance(other, type(self)):
             return False

--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -180,6 +180,12 @@ class OQPyExpression:
             "the equality of expressions using == instead of expr_matches."
         )
 
+    def _expr_matches(self, other) -> bool:
+        """Called by expr_matches to compare expression instances."""
+        if not isinstance(other, type(self)):
+            return False
+        return expr_matches(self.__dict__, other.__dict__)
+
 
 def _get_type(val: AstConvertible) -> Optional[ast.ClassicalType]:
     if isinstance(val, OQPyExpression):
@@ -332,7 +338,7 @@ def expr_matches(a: Any, b: Any) -> bool:
         return all(expr_matches(va, b[k]) for k, va in a.items())
     if isinstance(a, OQPyExpression):
         # Bypass `__eq__` which is overloaded on OQPyExpressions
-        return expr_matches(a.__dict__, b.__dict__)
+        return a._expr_matches(b)
     else:
         return a == b
 

--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -330,7 +330,8 @@ def expr_matches(a: Any, b: Any) -> bool:
         if a.keys() != b.keys():
             return False
         return all(expr_matches(va, b[k]) for k, va in a.items())
-    if hasattr(a, "__dict__") and type(a).__module__.startswith("oqpy"):
+    if isinstance(a, OQPyExpression):
+        # Bypass `__eq__` which is overloaded on OQPyExpressions
         return expr_matches(a.__dict__, b.__dict__)
     else:
         return a == b

--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -318,6 +318,8 @@ def expr_matches(a: Any, b: Any) -> bool:
 
     This bypasses calling ``__eq__`` on expr objects.
     """
+    if a is b:
+        return True
     if type(a) is not type(b):
         return False
     if isinstance(a, (list, np.ndarray)):
@@ -328,7 +330,7 @@ def expr_matches(a: Any, b: Any) -> bool:
         if a.keys() != b.keys():
             return False
         return all(expr_matches(va, b[k]) for k, va in a.items())
-    if hasattr(a, "__dict__"):
+    if hasattr(a, "__dict__") and type(a).__module__.startswith("oqpy"):
         return expr_matches(a.__dict__, b.__dict__)
     else:
         return a == b

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2624,3 +2624,28 @@ def test_box_with_negative_duration():
     with pytest.raises(ValueError, match="Expected a non-negative duration, but got -4e-09"):
         with Box(prog, -4e-9):
             pass
+
+
+def test_expr_matches_handles_outside_data():
+    x1 = oqpy.FloatVar(3, name="x")
+    x2 = oqpy.FloatVar(3, name="x")
+    class MyEntity:
+        def __init__(self):
+            self.self_ref = self
+
+        def __eq__(self, other):
+            return True
+
+    x1._entity = MyEntity()
+    x2._entity = MyEntity()
+    assert oqpy.base.expr_matches(x1, x2)
+
+    class MyEntityNoEq:
+        def __init__(self):
+            self.self_ref = self
+        def __eq__(self, other):
+            raise RuntimeError("Eq not allowed")
+
+    x1._entity = MyEntityNoEq()
+    x2._entity = x1._entity
+    oqpy.base.expr_matches(x1, x2)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2656,3 +2656,21 @@ def test_expr_matches_handles_outside_data():
     x1 = MyFloatVar(3, name="x")
     x2 = MyFloatVar(3, name="x")
     assert oqpy.base.expr_matches(x1, x2)
+
+    class MyFloatVarWithIgnoredData(oqpy.FloatVar):
+        ignored: int
+        def _expr_matches(self, other):
+            if not isinstance(other, type(self)):
+                return False
+            d1 = self.__dict__.copy()
+            d2 = other.__dict__.copy()
+            d1.pop("ignored")
+            d2.pop("ignored")
+            return oqpy.base.expr_matches(d1, d2)
+
+
+    x1 = MyFloatVarWithIgnoredData(3, name="x")
+    x1.ignored = 1
+    x2 = MyFloatVarWithIgnoredData(3, name="x")
+    x2.ignored = 2
+    assert oqpy.base.expr_matches(x1, x2)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2649,3 +2649,10 @@ def test_expr_matches_handles_outside_data():
     x1._entity = MyEntityNoEq()
     x2._entity = x1._entity
     oqpy.base.expr_matches(x1, x2)
+
+    class MyFloatVar(oqpy.FloatVar):
+        ...
+
+    x1 = MyFloatVar(3, name="x")
+    x2 = MyFloatVar(3, name="x")
+    assert oqpy.base.expr_matches(x1, x2)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2655,6 +2655,7 @@ def test_expr_matches_handles_outside_data():
 
     x1 = MyFloatVar(3, name="x")
     x2 = MyFloatVar(3, name="x")
+    assert not x1._expr_matches(oqpy.FloatVar(3, name="x"))
     assert oqpy.base.expr_matches(x1, x2)
 
     class MyFloatVarWithIgnoredData(oqpy.FloatVar):
@@ -2667,7 +2668,6 @@ def test_expr_matches_handles_outside_data():
             d1.pop("ignored")
             d2.pop("ignored")
             return oqpy.base.expr_matches(d1, d2)
-
 
     x1 = MyFloatVarWithIgnoredData(3, name="x")
     x1.ignored = 1


### PR DESCRIPTION
I am creating `oqpy` variables from some other representation, and I wanted to attach some extra data to the oqpy variables to indicate their provenance. When I did this, I got failures from `expr_matches` since it's method of traversing the `__dict__` recursively is not applicable to my data, which has reference cycles.

I've modified `expr_matches` so that it short circuits on object identity, and so that it only descends into `obj.__dict__` for objects from the oqpy package, rather than any externally produced data.