### PR TITLE
fix regression with cache

### DIFF
--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -363,7 +363,7 @@ class CachedExpressionConvertible(Protocol):
 
     _oqpy_cache_key: Hashable
 
-    def _to_cached_oqpy_expression(self) -> HasToAst: ...  # pragma: no cover
+    def _to_cached_oqpy_expression(self) -> AstConvertible: ...  # pragma: no cover
 
 
 class OQPyUnaryExpression(OQPyExpression):
@@ -490,8 +490,10 @@ def to_ast(program: Program, item: AstConvertible) -> ast.Expression:
         if item._oqpy_cache_key is None:
             item._oqpy_cache_key = uuid.uuid1()
         if item._oqpy_cache_key not in program.expr_cache:
-            program.expr_cache[item._oqpy_cache_key] = item._to_cached_oqpy_expression()
-        item = program.expr_cache[item._oqpy_cache_key]
+            program.expr_cache[item._oqpy_cache_key] = to_ast(
+                program, item._to_cached_oqpy_expression()
+            )
+        return program.expr_cache[item._oqpy_cache_key]
     if isinstance(item, (complex, np.complexfloating)):
         if item.imag == 0:
             return to_ast(program, item.real)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -1665,6 +1665,7 @@ def test_cached_expression_convertible():
     assert dur.count == 2
     # This gets computed just once
     assert frame.count == 1
+    assert all(isinstance(v, ast.QASMNode) for v in prog.expr_cache.values())
 
 
 def test_waveform_extern_arg_passing():


### PR DESCRIPTION
[This change](https://github.com/openqasm/oqpy/commit/f9d6fea5a3362853b60bc7abc77f23db1830e542#diff-ad6bf38aee582382f83e3cf14be4d415d51432682edfdafa145edbd54bf796d4R484) modified the cache objects. We were not caching the ast nodes anymore but the ouput of `to_cached_oqpy_expression`. This led to regression in benchmarks.

Solution: we store the ast in `Program.expr_cache`. I changed `to_cached_oqpy_expression` return type to be `AstConvertible` to match `to_oqpy_expression`. Consequently, we need to call the main `to_ast` function instead of `HasToAst.to_ast`.

Updated a unit test.
 