### PR TITLE
input tweaks and tests

### DIFF
--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -417,7 +417,7 @@ class ArrayVar(_ClassicalVar):
             array_base_type = base_type_instance.type_cls()
 
         # Automatically handle Duration array.
-        init = kwargs["init_expression"]
+        init = kwargs.get("init_expression")
         if (
             base_type is DurationVar
             and init is not None
@@ -427,9 +427,7 @@ class ArrayVar(_ClassicalVar):
                 and init == "input"
             )
         ):
-            kwargs["init_expression"] = (
-                convert_float_to_duration(i) for i in kwargs["init_expression"]
-            )
+            kwargs["init_expression"] = [convert_float_to_duration(i) for i in init]
 
         super().__init__(
             *args,

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -227,11 +227,12 @@ class _ClassicalVar(Var, OQPyExpression):
     def make_declaration_statement(self, program: Program) -> ast.Statement:
         """Make an ast statement that declares the OQpy variable."""
         if isinstance(self.init_expression, str) and self.init_expression in ("input", "output"):
-            return ast.IODeclaration(
+            stmt = ast.IODeclaration(
                 ast.IOKeyword[self.init_expression], self.type, self.to_ast(program)
             )
-        init_expression_ast = optional_ast(program, self.init_expression)
-        stmt = ast.ClassicalDeclaration(self.type, self.to_ast(program), init_expression_ast)
+        else:
+            init_expression_ast = optional_ast(program, self.init_expression)
+            stmt = ast.ClassicalDeclaration(self.type, self.to_ast(program), init_expression_ast)
         stmt.annotations = make_annotations(self.annotations)
         return stmt
 
@@ -416,7 +417,16 @@ class ArrayVar(_ClassicalVar):
             array_base_type = base_type_instance.type_cls()
 
         # Automatically handle Duration array.
-        if base_type is DurationVar and kwargs["init_expression"] is not None:
+        init = kwargs["init_expression"]
+        if (
+            base_type is DurationVar
+            and init is not None
+            and not (
+                # type check to avoid element-wise numpy comparison for array init
+                isinstance(init, str)
+                and init == "input"
+            )
+        ):
             kwargs["init_expression"] = (
                 convert_float_to_duration(i) for i in kwargs["init_expression"]
             )

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -309,6 +309,7 @@ def test_array_declaration():
         name="comp55", init_expression=[0, 1 + 1j], dimensions=[2], base_type=ComplexVar[float_(55)]
     )
     ang_partial = ArrayVar[AngleVar, 2](name="ang_part", init_expression=[oqpy.pi, oqpy.pi / 2])
+    arg_array = ArrayVar([1, 2, 3], name="arg_array", dimensions=[3])
     simple = ArrayVar[FloatVar](name="no_init", dimensions=[5])
     multidim = ArrayVar[FloatVar[32], 3, 2](
         name="multiDim", init_expression=[[1.1, 1.2], [2.1, 2.2], [3.1, 3.2]]
@@ -320,7 +321,7 @@ def test_array_declaration():
         base_type=DurationVar,
     )
 
-    vars = [b, b_in, i, i_in, d_in, i55, u, x, y, ang, comp, comp55, ang_partial, simple, multidim, npinit]
+    vars = [b, b_in, i, i_in, d_in, i55, u, x, y, ang, comp, comp55, ang_partial, arg_array, simple, multidim, npinit]
 
     prog = oqpy.Program(version=None)
     prog.declare(vars)
@@ -350,6 +351,7 @@ def test_array_declaration():
         array[complex[float[64]], 2] comp = {0, 1.0 + 1.0im};
         array[complex[float[55]], 2] comp55 = {0, 1.0 + 1.0im};
         array[angle[32], 2] ang_part = {pi, pi / 2};
+        array[int[32], 3] arg_array = {1, 2, 3};
         array[float[64], 5] no_init;
         array[float[32], 3, 2] multiDim = {{1.1, 1.2}, {2.1, 2.2}, {3.1, 3.2}};
         array[duration, 11] npinit = {0.0ns, 1.0ns, 2.0ns, 4.0ns};


### PR DESCRIPTION
Includes the following bug fixes:
* Annotations for variables declared as inputs are now correctly passed to the IODeclaration node
* Duration array inputs no longer attempt to convert the string `"input"` from float to duration

and adds tests