### PR TITLE
Fix issue with expr-matches and tuples with numpy arrays

### DIFF
--- a/oqpy/__init__.py
+++ b/oqpy/__init__.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 ############################################################################
 
-__version__ = "0.3.8"
+__version__ = "0.3.10"
 from oqpy.classical_types import *
 from oqpy.control_flow import *
 from oqpy.program import *

--- a/oqpy/base.py
+++ b/oqpy/base.py
@@ -328,7 +328,7 @@ def expr_matches(a: Any, b: Any) -> bool:
         return True
     if type(a) is not type(b):
         return False
-    if isinstance(a, (list, np.ndarray)):
+    if isinstance(a, (list, tuple, np.ndarray)):
         if len(a) != len(b):
             return False
         return all(expr_matches(ai, bi) for ai, bi in zip(a, b))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oqpy"
-version = "0.3.9"
+version = "0.3.10"
 description = "Generating OpenQASM 3 + OpenPulse in Python"
 authors = ["OQpy Contributors <oqpy-contributors@amazon.com>"]
 license = "Apache-2.0"

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2769,3 +2769,28 @@ def test_expr_matches_handles_outside_data():
     x2 = MyFloatVarWithIgnoredData(3, name="x")
     x2.ignored = 2
     assert oqpy.base.expr_matches(x1, x2)
+
+
+def test_expr_matches_with_numpy_array_attributes():
+    """Variables with numpy array data in extra attributes can be compared."""
+    x1 = oqpy.FloatVar(3, name="x")
+    x2 = oqpy.FloatVar(3, name="x")
+
+    # Numpy array directly as an attribute works (ndarray branch handles it).
+    x1.data = np.array([1.0, 2.0, 3.0])
+    x2.data = np.array([1.0, 2.0, 3.0])
+    assert expr_matches(x1, x2)
+
+    # Numpy array inside a tuple triggers tuple.__eq__ which delegates to
+    # numpy element-wise ==, producing an array instead of a bool.
+    x1.data = ("sweep", np.array([1.0, 2.0, 3.0]))
+    x2.data = ("sweep", np.array([1.0, 2.0, 3.0]))
+    assert expr_matches(x1, x2)
+
+    # Non-matching arrays should return False, not raise.
+    x2.data = ("sweep", np.array([4.0, 5.0, 6.0]))
+    assert not expr_matches(x1, x2)
+
+    # Non-matching tuple lengths should return False.
+    x2.data = ("sweep",)
+    assert not expr_matches(x1, x2)


### PR DESCRIPTION
The `expr_matches` routine can produce a failure if numpy data is inside a tuple. Currently, tuples are compared by equality, and if the tuple contains a numpy array,  this can result in numpy arrays being compared by equality, which produces an array rather than a bool.